### PR TITLE
L3 integration for Containers

### DIFF
--- a/libpkt/libpkt.go
+++ b/libpkt/libpkt.go
@@ -1,0 +1,386 @@
+package libpkt
+
+import (
+	"bytes"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/ofnet/ovsdbDriver"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"net"
+	"time"
+)
+
+var (
+	snapshot_len int32 = 1024
+	err          error
+	timeout      time.Duration = 30 * time.Second
+	handle       *pcap.Handle
+	// Will reuse these for each packet
+	ethLayer  layers.Ethernet
+	ipLayer   layers.IPv4
+	tcpLayer  layers.TCP
+	vlanLayer layers.Dot1Q
+	options   gopacket.SerializeOptions
+)
+
+type Packet struct {
+	SrcMAC string // src mac
+	DstMAC string // dst mac
+	IPv4   *IPv4Layer
+	IPv6   *IPv6Layer
+	Arp    *ArpLayer
+}
+
+type IPv4Layer struct {
+	SrcIP      string // Src ip address
+	DstIP      string // dst ip address
+	srcPort    int    // src tcp port
+	dstPort    int    // dst tcp port
+	TTL        uint8  // ip TTL
+	IHL        uint8
+	TOS        uint8
+	Length     uint16
+	Id         uint16
+	Flags      uint8
+	FragOffset uint16
+	Protocol   layers.IPProtocol
+	Checksum   uint16
+	Options    []layers.IPv4Option
+	Padding    []byte
+}
+type IPv6Layer struct {
+	SrcIP        string // Src ip address
+	DstIP        string // dst ip address
+	srcPort      int    // src tcp port
+	dstPort      int    // dst tcp port
+	TrafficClass uint8
+	FlowLabel    uint32
+	Length       uint16
+	Protocol     uint8
+	HopLimit     uint8
+	NextHeader   layers.IPProtocol
+}
+
+type ArpLayer struct {
+	AddrType          layers.LinkType
+	Protocol          layers.EthernetType
+	HwAddressSize     uint8
+	ProtAddressSize   uint8
+	Operation         uint16
+	SourceHwAddress   string
+	SourceProtAddress string
+	DstHwAddress      string
+	DstProtAddress    string
+}
+
+func compareIP(A net.IP, B net.IP) bool {
+
+	return bytes.Equal(A, B)
+}
+func buildIpv4(ipv4Layer *IPv4Layer) (ip *layers.IPv4) {
+
+	ip = &layers.IPv4{
+		Id:       1,
+		TTL:      64,
+		IHL:      20,
+		SrcIP:    net.ParseIP(ipv4Layer.SrcIP),
+		DstIP:    net.ParseIP(ipv4Layer.DstIP),
+		Version:  4,
+		Length:   0,
+		Protocol: 255,
+		Checksum: 0,
+	}
+	switch {
+	case ipv4Layer.Id > 0:
+		ip.Id = ipv4Layer.Id
+	case ipv4Layer.TTL > 0:
+		ip.TTL = ipv4Layer.TTL
+	case ipv4Layer.IHL > 0:
+		ip.IHL = ipv4Layer.IHL
+	}
+	return
+}
+
+func buildIpv6(ipv6Layer *IPv6Layer) (ip *layers.IPv6) {
+
+	ip = &layers.IPv6{
+		SrcIP:      net.ParseIP(ipv6Layer.SrcIP),
+		DstIP:      net.ParseIP(ipv6Layer.DstIP),
+		Version:    6,
+		Length:     46,
+		NextHeader: layers.IPProtocolNoNextHeader,
+		HopLimit:   64,
+	}
+	return
+}
+
+func buildArp(arpLayer *ArpLayer) (arp *layers.ARP) {
+
+	SourceHwAddress, _ := net.ParseMAC(arpLayer.SourceHwAddress)
+	DstHwAddress, _ := net.ParseMAC(arpLayer.DstHwAddress)
+
+	arp = &layers.ARP{
+		AddrType:          layers.LinkTypeEthernet,
+		Protocol:          layers.EthernetTypeIPv4,
+		HwAddressSize:     6,
+		ProtAddressSize:   4,
+		Operation:         arpLayer.Operation,
+		SourceHwAddress:   SourceHwAddress,
+		SourceProtAddress: net.ParseIP(arpLayer.SourceProtAddress),
+		DstHwAddress:      DstHwAddress,
+		DstProtAddress:    net.ParseIP(arpLayer.DstProtAddress),
+	}
+	return
+}
+
+func SendPacket(ovsDriver *ovsdbDriver.OvsDriver, srcPort string, pkt *Packet, numPkts int) error {
+
+	options = gopacket.SerializeOptions{}
+	var buffer gopacket.SerializeBuffer
+	handle, err = pcap.OpenLive("port12", snapshot_len, true, pcap.BlockForever)
+	if err != nil {
+		log.Errorf("openlive: %v", err)
+		return err
+	}
+	defer handle.Close()
+
+	buffer = gopacket.NewSerializeBuffer()
+	options.FixLengths = true
+	options.ComputeChecksums = true
+
+	sMac, _ := net.ParseMAC(pkt.SrcMAC)
+	dMac, _ := net.ParseMAC(pkt.DstMAC)
+	ethLayer := &layers.Ethernet{
+		SrcMAC: sMac,
+		DstMAC: dMac,
+	}
+	switch {
+	case pkt.Arp != nil:
+		arpLayer := buildArp(pkt.Arp)
+		log.Infof("Sending an ARP packet on %s", srcPort)
+		ethLayer.EthernetType = layers.EthernetTypeARP
+		gopacket.SerializeLayers(buffer,
+			options,
+			ethLayer,
+			arpLayer)
+	case pkt.IPv4 != nil:
+		ipLayer := buildIpv4(pkt.IPv4)
+		log.Infof("Sending an IPv4 packer on %s", srcPort)
+		ethLayer.EthernetType = layers.EthernetTypeIPv4
+		gopacket.SerializeLayers(buffer,
+			options,
+			ethLayer,
+			ipLayer)
+	case pkt.IPv6 != nil:
+		fmt.Println("ipv6")
+		log.Infof("Sending an IPv6 packet on %s", srcPort)
+		ipLayer := buildIpv6(pkt.IPv6)
+		ethLayer.EthernetType = layers.EthernetTypeIPv6
+		gopacket.SerializeLayers(buffer,
+			options,
+			ethLayer,
+			ipLayer)
+	default:
+		ethLayer.EthernetType = 0xFFFF
+		log.Infof("Sending an Ethernet packet on %s", srcPort)
+		gopacket.SerializeLayers(buffer,
+			options,
+			ethLayer)
+	}
+
+	outgoingPacket := buffer.Bytes()
+	for i := 0; i < numPkts; i++ {
+		fmt.Println(outgoingPacket)
+		handle.WritePacketData(outgoingPacket)
+	}
+
+	return err
+}
+
+/*
+func readPacket(handle *pcap.Handle, pkt *Packet, dstPort string) int {
+	log.Infof("Received: Decoding the packet ")
+	pktTimer := time.NewTimer(time.Second * 120)
+	verifiedCount := 0
+	count := 0
+	src := gopacket.NewPacketSource(handle, layers.LayerTypeEthernet)
+	for {
+		select {
+		case <-pktTimer.C:
+			fmt.Println("Verified count --->", verifiedCount)
+			return verifiedCount
+		case packet := <-src.Packets():
+			count++
+			fmt.Println("This is the loop no:", count)
+			switch {
+			case pkt.Arp != nil:
+				arpLayer := packet.Layer(layers.LayerTypeARP)
+				if arpLayer == nil {
+					continue
+				}
+				arp := arpLayer.(*layers.ARP)
+				if compareIP(arp.SourceProtAddress, net.ParseIP(pkt.Arp.SourceProtAddress)) {
+					if compareIP(arp.DstProtAddress, net.ParseIP(pkt.Arp.DstProtAddress)) {
+						log.Infof("Verified: Received ARP packetfrom %v", arp.SourceProtAddress)
+						verifiedCount++
+					}
+				}
+			case pkt.IPv4 != nil:
+				ipLayer := packet.Layer(layers.LayerTypeIPv4)
+				if ipLayer == nil {
+					continue
+				}
+				ip := ipLayer.(*layers.IPv4)
+				fmt.Println("Received IPv4 packet from %v on %s", ip.SrcIP, dstPort)
+				if compareIP(ip.SrcIP.To16(), net.ParseIP(pkt.IPv4.SrcIP)) {
+					if compareIP(ip.DstIP.To16(), net.ParseIP(pkt.IPv4.DstIP)) {
+						fmt.Println("Incrementing the count")
+						fmt.Println("Verified: Received IPv4 packet from %v on %s", ip.SrcIP, dstPort)
+						verifiedCount++
+					}
+				}
+			case pkt.IPv6 != nil:
+				ipLayer := packet.Layer(layers.LayerTypeIPv6)
+				if ipLayer == nil {
+					continue
+				}
+				ip := ipLayer.(*layers.IPv6)
+				if compareIP(ip.SrcIP, net.ParseIP(pkt.IPv6.SrcIP)) {
+					if compareIP(ip.DstIP, net.ParseIP(pkt.IPv6.DstIP)) {
+						log.Infof("Verified: Received IPv6 Packet from %v on %s", ip.SrcIP, dstPort)
+						verifiedCount++
+					}
+				}
+			default:
+				ethLayer := packet.Layer(layers.LayerTypeEthernet)
+				eth := ethLayer.(*layers.Ethernet)
+				log.Infof("Verified: Received ethernet packet from %v", eth.SrcMAC)
+			}
+		}
+	}
+}
+func VerifyPacket(ovsDriver *ovsdbDriver.OvsDriver, dstPort string, pkt *Packet, ch chan bool, timeout int, numPkts int) {
+	pktTimer := time.NewTimer(time.Second * 120)
+	verifiedCountTotal := 0
+		handle, err := pcap.OpenLive(dstPort, 1024, true, pcap.BlockForever)
+		if err != nil {
+			fmt.Println("Error capturing packet")
+			continue
+		}
+		if handle == nil {
+			continue
+		}
+		defer handle.Close()
+		// Start up a goroutine to read in packet data.
+		//	stop := make(chan struct{}, 1)
+		//defer close(stop)
+		//done := make(chan int, 1000)
+		for {
+		fmt.Println("Calling Go routine Read packet", numPkts)
+		verifiedCountTotal += readPacket(handle, pkt, dstPort)
+		select {
+		case <-pktTimer.C:
+			fmt.Println(verifiedCountTotal)
+			ch <- (verifiedCountTotal == numPkts)
+			//close(stop)
+			return
+		default:
+			continue
+		}
+	}
+}*/
+func readPacket(handle *pcap.Handle, pkt *Packet, dstPort string, done chan int) {
+	log.Infof("Received: Decoding the packet ")
+
+	pktTimer := time.NewTimer(time.Second * 20)
+	verifiedCount := 0
+	count := 0
+	src := gopacket.NewPacketSource(handle, layers.LayerTypeEthernet)
+	for {
+		select {
+		case <-pktTimer.C:
+			fmt.Println("Verified count --->", verifiedCount)
+			done <- verifiedCount
+		case packet := <-src.Packets():
+			count++
+			fmt.Println("This is the loop no:", count)
+			switch {
+			case pkt.Arp != nil:
+				arpLayer := packet.Layer(layers.LayerTypeARP)
+				if arpLayer == nil {
+					continue
+				}
+				arp := arpLayer.(*layers.ARP)
+				if compareIP(arp.SourceProtAddress, net.ParseIP(pkt.Arp.SourceProtAddress)) {
+					if compareIP(arp.DstProtAddress, net.ParseIP(pkt.Arp.DstProtAddress)) {
+						log.Infof("Verified: Received ARP packetfrom %v", arp.SourceProtAddress)
+						verifiedCount++
+					}
+				}
+			case pkt.IPv4 != nil:
+				ipLayer := packet.Layer(layers.LayerTypeIPv4)
+				if ipLayer == nil {
+					continue
+				}
+				ip := ipLayer.(*layers.IPv4)
+
+				fmt.Println("Received IPv4 packet from %v on %s", ip.SrcIP, dstPort)
+				if compareIP(ip.SrcIP.To16(), net.ParseIP(pkt.IPv4.SrcIP)) {
+					if compareIP(ip.DstIP.To16(), net.ParseIP(pkt.IPv4.DstIP)) {
+						fmt.Println("Incrementing the count")
+						fmt.Println("Verified: Received IPv4 packet from %v on %s", ip.SrcIP, dstPort)
+						verifiedCount++
+					}
+				}
+			case pkt.IPv6 != nil:
+				ipLayer := packet.Layer(layers.LayerTypeIPv6)
+				if ipLayer == nil {
+					continue
+				}
+				ip := ipLayer.(*layers.IPv6)
+				if compareIP(ip.SrcIP, net.ParseIP(pkt.IPv6.SrcIP)) {
+					if compareIP(ip.DstIP, net.ParseIP(pkt.IPv6.DstIP)) {
+						log.Infof("Verified: Received IPv6 Packet from %v on %s", ip.SrcIP, dstPort)
+						verifiedCount++
+					}
+				}
+			default:
+				ethLayer := packet.Layer(layers.LayerTypeEthernet)
+				eth := ethLayer.(*layers.Ethernet)
+				if eth.SrcMAC.String() == pkt.SrcMAC && eth.DstMAC.String() == pkt.DstMAC {
+					log.Infof("Verified: Received Eth Packet from %v on %s", eth.SrcMAC, dstPort)
+					verifiedCount++
+				}
+			}
+		}
+	}
+}
+
+func VerifyPacket(ovsDriver *ovsdbDriver.OvsDriver, dstPort string, pkt *Packet, ch chan bool, timeout int, numPkts int) {
+	verifiedCountTotal := 0
+	handle, err := pcap.OpenLive(dstPort, 1024, true, pcap.BlockForever)
+
+	if err != nil {
+		fmt.Println("Error capturing packet")
+		ch <- false
+	}
+
+	if handle == nil {
+		ch <- false
+	}
+	defer handle.Close()
+	// Start up a goroutine to read in packet data.
+	//	stop := make(chan struct{}, 1)
+	//defer close(stop)
+	done := make(chan int)
+
+	fmt.Println("Calling Go routine Read packet", numPkts)
+	go readPacket(handle, pkt, dstPort, done)
+	verifiedCountTotal = <-done
+	fmt.Println(verifiedCountTotal)
+	ch <- (verifiedCountTotal == numPkts)
+	close(done)
+	return
+}

--- a/ofnet.go
+++ b/ofnet.go
@@ -89,6 +89,9 @@ type OfnetProto interface {
 
 	//Delete Local Route
 	DeleteLocalProtoRoute(path *OfnetProtoRouteInfo) error
+
+	//Modify protocol Rib (Could be used for testing)
+	ModifyProtoRib(path interface{})
 }
 
 // Default port numbers

--- a/ofnet.go
+++ b/ofnet.go
@@ -65,7 +65,8 @@ type OfnetDatapath interface {
 
 // Default port numbers
 const OFNET_MASTER_PORT = 9001
-const OFNET_AGENT_PORT = 9002
+const OFNET_AGENT_VXLAN_PORT = 9002
+const OFNET_AGENT_VLAN_PORT = 9010
 
 // Information about each node
 type OfnetNode struct {

--- a/ofnet.go
+++ b/ofnet.go
@@ -61,6 +61,12 @@ type OfnetDatapath interface {
 
 	// Remove a vlan
 	RemoveVlan(vlanId uint16, vni uint32) error
+
+	//Add uplink port
+	AddUplink(portNo uint32) error
+
+	//Delete uplink port
+	RemoveUplink(portNo uint32) error
 }
 
 // Interface implemented by each control protocol.
@@ -74,8 +80,15 @@ type OfnetProto interface {
 
 	//Delete a Protocol Neighbor
 	DeleteProtoNeighbor() error
+
 	//Get Protocol router info
 	GetRouterInfo() *OfnetProtoRouterInfo
+
+	//Add Local Route
+	AddLocalProtoRoute(path *OfnetProtoRouteInfo) error
+
+	//Delete Local Route
+	DeleteLocalProtoRoute(path *OfnetProtoRouteInfo) error
 }
 
 // Default port numbers
@@ -130,4 +143,10 @@ type OfnetProtoRouterInfo struct {
 	ProtocolType string // type of protocol
 	RouterIP     string // ip address of the neighbor
 	VlanIntf     string // uplink L2 intf
+}
+
+type OfnetProtoRouteInfo struct {
+	ProtocolType string // type of protocol
+	localEpIP    string
+	nextHopIP    string
 }

--- a/ofnet.go
+++ b/ofnet.go
@@ -91,6 +91,7 @@ type OfnetEndpoint struct {
 // OfnetPolicyRule has security rule to be installed
 type OfnetPolicyRule struct {
 	RuleId           string // Unique identifier for the rule
+	Priority         int    // Priority for the rule (1..100. 100 is highest)
 	SrcEndpointGroup int    // Source endpoint group
 	DstEndpointGroup int    // Destination endpoint group
 	SrcIpAddr        string // source IP addrss and mask

--- a/ofnet.go
+++ b/ofnet.go
@@ -77,7 +77,7 @@ type OfnetNode struct {
 type OfnetEndpoint struct {
 	EndpointID    string    // Unique identifier for the endpoint
 	EndpointType  string    // Type of the endpoint "internal", "external" or "externalRoute"
-	EndpointGroup uint32    // Endpoint group identifier for policies.
+	EndpointGroup int       // Endpoint group identifier for policies.
 	IpAddr        net.IP    // IP address of the end point
 	VrfId         uint16    // IP address namespace
 	MacAddrStr    string    // Mac address of the end point(in string format)
@@ -91,11 +91,12 @@ type OfnetEndpoint struct {
 // OfnetPolicyRule has security rule to be installed
 type OfnetPolicyRule struct {
 	RuleId           string // Unique identifier for the rule
-	SrcEndpointGroup uint32 // Source endpoint group
-	DstEndpointGroup uint32 // Destination endpoint group
+	SrcEndpointGroup int    // Source endpoint group
+	DstEndpointGroup int    // Destination endpoint group
 	SrcIpAddr        string // source IP addrss and mask
 	DstIpAddr        string // Destination IP address and mask
 	IpProtocol       uint8  // IP protocol number
 	SrcPort          uint16 // Source port
 	DstPort          uint16 // destination port
+	Action           string // rule action: 'accept' or 'deny'
 }

--- a/ofnet.go
+++ b/ofnet.go
@@ -63,6 +63,21 @@ type OfnetDatapath interface {
 	RemoveVlan(vlanId uint16, vni uint32) error
 }
 
+// Interface implemented by each control protocol.
+type OfnetProto interface {
+
+	//Create a protocol server
+	StartProtoServer(routerInfo OfnetProtoRouterInfo) error
+
+	//Add a Protocol Neighbor
+	AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) error
+
+	//Delete a Protocol Neighbor
+	DeleteProtoNeighbor() error
+	//Get Protocol router info
+	GetRouterInfo() *OfnetProtoRouterInfo
+}
+
 // Default port numbers
 const OFNET_MASTER_PORT = 9001
 const OFNET_AGENT_VXLAN_PORT = 9002
@@ -103,4 +118,16 @@ type OfnetPolicyRule struct {
 	DstPort          uint16 // destination port
 	TcpFlags         string // TCP flags to match: syn || syn,ack || ack || syn,!ack || !syn,ack;
 	Action           string // rule action: 'accept' or 'deny'
+}
+
+type OfnetProtoNeighborInfo struct {
+	ProtocolType string // type of protocol
+	NeighborIP   string // ip address of the neighbor
+	As           string // As of neighbor if applicable
+}
+
+type OfnetProtoRouterInfo struct {
+	ProtocolType string // type of protocol
+	RouterIP     string // ip address of the neighbor
+	VlanIntf     string // uplink L2 intf
 }

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -599,13 +599,17 @@ func (self *OfnetAgent) Serve() error {
 	}
 
 	routerId := self.routerIP
+	if routerId = nil {
+		log.Errorf("Invalid router IP. Bgp service aborted")
+		return
+	}
 	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(32), routerId).Serialize()
 	n, _ := bgp.NewPathAttributeNextHop("0.0.0.0").Serialize()
 	path.Pattrs = append(path.Pattrs, n)
 	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE).Serialize()
 	path.Pattrs = append(path.Pattrs, origin)
 
-	err = self.ovsDriver.CreatePort("inb01", "internal", 1)
+	err = self.ovsDriver.CreatePort("inb01", "internal", 1)    
 	if err != nil {
 		log.Errorf("Error creating the port", err)
 	}
@@ -618,7 +622,12 @@ func (self *OfnetAgent) Serve() error {
 
 	if intf == nil || ofPortno == 0 {
 		log.Errorf("Error fetching inb01 information", intf, ofPortno)
+		return
 	}
+
+
+
+	if
 
 	epreg := &OfnetEndpoint{
 		EndpointID:   routerId,

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -626,9 +626,6 @@ func (self *OfnetAgent) Serve() error {
 	}
 
 
-
-	if
-
 	epreg := &OfnetEndpoint{
 		EndpointID:   routerId,
 		EndpointType: "internal-bgp",

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -71,6 +71,7 @@ type EndpointInfo struct {
 	MacAddr       net.HardwareAddr
 	Vlan          uint16
 	IpAddr        net.IP
+	VrfId         uint16
 }
 
 const FLOW_MATCH_PRIORITY = 100        // Priority for all match flows
@@ -280,7 +281,7 @@ func (self *OfnetAgent) RemoveMaster(masterInfo *OfnetNode) error {
 }
 
 // Add a local endpoint.
-// This takes ofp port number, mac address, vlan and IP address of the port.
+// This takes ofp port number, mac address, vlan , VrfId and IP address of the port.
 func (self *OfnetAgent) AddLocalEndpoint(endpoint EndpointInfo) error {
 	// Add port vlan mapping
 	self.portVlanMap[endpoint.PortNo] = &endpoint.Vlan
@@ -300,7 +301,7 @@ func (self *OfnetAgent) AddLocalEndpoint(endpoint EndpointInfo) error {
 		EndpointType:  "internal",
 		EndpointGroup: endpoint.EndpointGroup,
 		IpAddr:        endpoint.IpAddr,
-		VrfId:         0, // FIXME set VRF correctly
+		VrfId:         endpoint.Vlan, //This has to be changed to vrfId when there is multi network per vrf support
 		MacAddrStr:    endpoint.MacAddr.String(),
 		Vlan:          endpoint.Vlan,
 		Vni:           *vni,

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -109,7 +109,8 @@ const MAC_DEST_TBL_ID = 5
 /*routerInfo[0] - > IP of the router intf
   routerInfo[1] -> Uplink nexthop interface
 */
-func NewOfnetAgent(dpName string, localIp net.IP, rpcPort uint16, ovsPort uint16, routerInfo ...string) (*OfnetAgent, error) {
+func NewOfnetAgent(dpName string, localIp net.IP, rpcPort uint16,
+	ovsPort uint16, routerInfo ...string) (*OfnetAgent, error) {
 	agent := new(OfnetAgent)
 
 	// Init params
@@ -756,7 +757,8 @@ func (self *OfnetAgent) modRib(path *api.Path) error {
 	}
 
 	endpointIPNet, _ := netlink.ParseIPNet(nlri.String())
-	log.Infof("Bgp Rib Received endpoint update for %v , with nexthop %v", endpointIPNet, nextHop)
+	log.Infof("Bgp Rib Received endpoint update for %v , with nexthop %v",
+		endpointIPNet, nextHop)
 
 	//check if bgp published a route local to the host
 	epid := endpointIPNet.IP.Mask(endpointIPNet.Mask).String()
@@ -971,7 +973,8 @@ func SetNeighborConfigValues(neighbor *bgpconf.Neighbor) error {
 	neighbor.Timers.TimersConfig.ConnectRetry = float64(bgpconf.DEFAULT_CONNECT_RETRY)
 	neighbor.Timers.TimersConfig.HoldTime = float64(bgpconf.DEFAULT_HOLDTIME)
 	neighbor.Timers.TimersConfig.KeepaliveInterval = float64(bgpconf.DEFAULT_HOLDTIME / 3)
-	neighbor.Timers.TimersConfig.IdleHoldTimeAfterReset = float64(bgpconf.DEFAULT_IDLE_HOLDTIME_AFTER_RESET)
+	neighbor.Timers.TimersConfig.IdleHoldTimeAfterReset =
+		float64(bgpconf.DEFAULT_IDLE_HOLDTIME_AFTER_RESET)
 	//FIX ME need to check with global peer to set internal or external
 	neighbor.NeighborConfig.PeerType = bgpconf.PEER_TYPE_EXTERNAL
 	neighbor.Transport.TransportConfig.PassiveMode = false
@@ -1008,7 +1011,8 @@ func (self *OfnetAgent) monitorPeer() error {
 			log.Errorf("MonitorPeerState stream failed :", err)
 			break
 		}
-		fmt.Printf("[NEIGH] %s fsm: %s admin: %s\n", s.Conf.NeighborAddress, s.Info.BgpState, s.Info.AdminState)
+		fmt.Printf("[NEIGH] %s fsm: %s admin: %s\n", s.Conf.NeighborAddress,
+			s.Info.BgpState, s.Info.AdminState)
 		if oldState == "BGP_FSM_ESTABLISHED" && oldAdminState == "ADMIN_STATE_UP" {
 			uplink, _ := self.ovsDriver.GetOfpPortNo(self.vlanIntf)
 			/*If the state changed from being established to idle or active:

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -587,7 +587,7 @@ Bgp serve routine does the following:
 3) Kicks off routines to monitor route updates and peer state
 */
 func (self *OfnetAgent) Serve() error {
-	//time.Sleep(5 * time.Second)
+	time.Sleep(5 * time.Second)
 	self.WaitForSwitchConnection()
 
 	self.modRibCh = make(chan *api.Path, 16)

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -563,3 +563,23 @@ func (self *OfnetAgent) DeleteBgpNeighbors() error {
 func (self *OfnetAgent) GetRouterInfo() *OfnetProtoRouterInfo {
 	return self.protopath.GetRouterInfo()
 }
+
+func (self *OfnetAgent) AddLocalProtoRoute(path *OfnetProtoRouteInfo) {
+	if self.protopath != nil {
+		self.protopath.AddLocalProtoRoute(path)
+	}
+}
+
+func (self *OfnetAgent) DeleteLocalProtoRoute(path *OfnetProtoRouteInfo) {
+	if self.protopath != nil {
+		self.protopath.DeleteLocalProtoRoute(path)
+	}
+}
+
+func (self *OfnetAgent) AddUplink(portNo uint32) error {
+	return self.datapath.AddUplink(portNo)
+}
+
+func (self *OfnetAgent) RemoveUplink(portNo uint32) error {
+	return self.datapath.RemoveUplink(portNo)
+}

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -66,15 +66,22 @@ type OfnetAgent struct {
 
 // local End point information
 type EndpointInfo struct {
-	PortNo  uint32
-	MacAddr net.HardwareAddr
-	Vlan    uint16
-	IpAddr  net.IP
+	PortNo        uint32
+	EndpointGroup uint32
+	MacAddr       net.HardwareAddr
+	Vlan          uint16
+	IpAddr        net.IP
 }
 
 const FLOW_MATCH_PRIORITY = 100 // Priority for all match flows
 const FLOW_FLOOD_PRIORITY = 10  // Priority for flood entries
 const FLOW_MISS_PRIORITY = 1    // priority for table miss flow
+
+const VLAN_TBL_ID = 1
+const DST_GRP_TBL_ID = 2
+const POLICY_TBL_ID = 3
+const IP_TBL_ID = 4
+const MAC_DEST_TBL_ID = 5
 
 // Create a new Ofnet agent and initialize it
 func NewOfnetAgent(dpName string, localIp net.IP, rpcPort uint16, ovsPort uint16) (*OfnetAgent, error) {
@@ -185,6 +192,17 @@ func (self *OfnetAgent) IsSwitchConnected() bool {
 	return self.isConnected
 }
 
+// WaitForSwitchConnection wait till switch connects
+func (self *OfnetAgent) WaitForSwitchConnection() {
+	// Wait for a while for OVS switch to connect to ofnet agent
+	for i := 0; i < 20; i++ {
+		time.Sleep(1 * time.Second)
+		if self.IsSwitchConnected() {
+			break
+		}
+	}
+}
+
 // Receive a packet from the switch.
 func (self *OfnetAgent) PacketRcvd(sw *ofctrl.OFSwitch, pkt *ofctrl.PacketIn) {
 	log.Infof("Packet received from switch %v. Packet: %+v", sw.DPID(), pkt)
@@ -277,16 +295,17 @@ func (self *OfnetAgent) AddLocalEndpoint(endpoint EndpointInfo) error {
 
 	// Build endpoint registry info
 	epreg := &OfnetEndpoint{
-		EndpointID:   epId,
-		EndpointType: "internal",
-		IpAddr:       endpoint.IpAddr,
-		VrfId:        0, // FIXME set VRF correctly
-		MacAddrStr:   endpoint.MacAddr.String(),
-		Vlan:         endpoint.Vlan,
-		Vni:          *vni,
-		OriginatorIp: self.localIp,
-		PortNo:       endpoint.PortNo,
-		Timestamp:    time.Now(),
+		EndpointID:    epId,
+		EndpointType:  "internal",
+		EndpointGroup: endpoint.EndpointGroup,
+		IpAddr:        endpoint.IpAddr,
+		VrfId:         0, // FIXME set VRF correctly
+		MacAddrStr:    endpoint.MacAddr.String(),
+		Vlan:          endpoint.Vlan,
+		Vni:           *vni,
+		OriginatorIp:  self.localIp,
+		PortNo:        endpoint.PortNo,
+		Timestamp:     time.Now(),
 	}
 
 	// Call the datapath
@@ -418,7 +437,7 @@ func (self *OfnetAgent) RemoveVlan(vlanId uint16, vni uint32) error {
 
 // Add remote endpoint RPC call from master
 func (self *OfnetAgent) EndpointAdd(epreg *OfnetEndpoint, ret *bool) error {
-	log.Infof("EndpointAdd rpc call for endpoint: %+v", epreg)
+	log.Infof("EndpointAdd rpc call for endpoint: %+v. localIp: %v", epreg, self.localIp)
 
 	// If this is a local endpoint we are done
 	if epreg.OriginatorIp.String() == self.localIp.String() {

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -73,9 +73,10 @@ type EndpointInfo struct {
 	IpAddr        net.IP
 }
 
-const FLOW_MATCH_PRIORITY = 100 // Priority for all match flows
-const FLOW_FLOOD_PRIORITY = 10  // Priority for flood entries
-const FLOW_MISS_PRIORITY = 1    // priority for table miss flow
+const FLOW_MATCH_PRIORITY = 100        // Priority for all match flows
+const FLOW_FLOOD_PRIORITY = 10         // Priority for flood entries
+const FLOW_MISS_PRIORITY = 1           // priority for table miss flow
+const FLOW_POLICY_PRIORITY_OFFSET = 10 // Priority offset for policy rules
 
 const VLAN_TBL_ID = 1
 const DST_GRP_TBL_ID = 2

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -218,7 +218,7 @@ func (self *OfnetAgent) AddMaster(masterInfo *OfnetNode, ret *bool) error {
 	// Register the agent with the master
 	err := rpcHub.Client(master.HostAddr, master.HostPort).Call("OfnetMaster.RegisterNode", &myInfo, &resp)
 	if err != nil {
-		log.Fatalf("Failed to register with the master %+v. Err: %v", master, err)
+		log.Errorf("Failed to register with the master %+v. Err: %v", master, err)
 		return err
 	}
 

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -67,7 +67,7 @@ type OfnetAgent struct {
 // local End point information
 type EndpointInfo struct {
 	PortNo        uint32
-	EndpointGroup uint32
+	EndpointGroup int
 	MacAddr       net.HardwareAddr
 	Vlan          uint16
 	IpAddr        net.IP

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -446,10 +446,8 @@ func (self *OfnetAgent) AddNetwork(vlanId uint16, vni uint32, Gw string) error {
 			Timestamp:    time.Now(),
 		}
 		self.endpointDb[Gw] = epreg
-		return self.datapath.AddVlan(vlanId, vni)
 	}
-	return nil
-
+	return self.datapath.AddVlan(vlanId, vni)
 }
 
 // Remove a vlan from datapath

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -44,9 +44,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	//"os"
-	//"os/signal"
-	//"syscall"
 )
 
 // OfnetAgent state
@@ -77,11 +74,14 @@ type OfnetAgent struct {
 	endpointDb      map[string]*OfnetEndpoint // all known endpoints
 	localEndpointDb map[uint32]*OfnetEndpoint // local port to endpoint map
 
-	modRibCh   chan *api.Path
+	//bgp resources
+	modRibCh   chan *api.Path //channel for route change notif
 	advPathCh  chan *api.Path
-	bgpServer  *bgpserver.BgpServer
-	grpcServer *bgpserver.Server
-	ovsDriver  *ovsdbDriver.OvsDriver
+	bgpServer  *bgpserver.BgpServer // bgp server instance
+	grpcServer *bgpserver.Server    // grpc server to talk to gobgp
+	myBgpPeer  string               // bgp peer ip
+
+	ovsDriver *ovsdbDriver.OvsDriver
 }
 
 // local End point information
@@ -106,6 +106,9 @@ const IP_TBL_ID = 4
 const MAC_DEST_TBL_ID = 5
 
 // Create a new Ofnet agent and initialize it
+/*routerInfo[0] - > IP of the router intf
+  routerInfo[1] -> Uplink nexthop interface
+*/
 func NewOfnetAgent(dpName string, localIp net.IP, rpcPort uint16, ovsPort uint16, routerInfo ...string) (*OfnetAgent, error) {
 	agent := new(OfnetAgent)
 
@@ -113,15 +116,16 @@ func NewOfnetAgent(dpName string, localIp net.IP, rpcPort uint16, ovsPort uint16
 	agent.localIp = localIp
 	agent.MyPort = rpcPort
 	agent.MyAddr = localIp.String()
-	if len(routerInfo) > 0 {
-		//Ensuring routerInfo is ip
+	if len(routerInfo) > 1 {
+		//Ensuring routerInfo is in ip format
 		if ok := net.ParseIP(routerInfo[0]); ok != nil {
 			agent.routerIP = routerInfo[0]
+		} else {
+			log.Errorf("Error creating OfnetAgent")
+			return nil, errors.New("Error parsing IP")
 		}
 		agent.vlanIntf = routerInfo[1]
 	}
-
-	log.Infof("ADDING OFNET AGENT LOCALIP IS ", agent.MyAddr)
 
 	agent.masterDb = make(map[string]*OfnetNode)
 	agent.portVlanMap = make(map[uint32]*uint16)
@@ -162,6 +166,7 @@ func NewOfnetAgent(dpName string, localIp net.IP, rpcPort uint16, ovsPort uint16
 		agent.datapath = NewVlrouter(agent, rpcServ)
 		agent.ovsDriver = ovsdbDriver.NewOvsDriver("contivVlanBridge")
 		agent.bgpServer, agent.grpcServer = CreateBgpServer()
+		//go routine to start gobgp server
 		go func() {
 			err := agent.Serve()
 			if err != nil {
@@ -450,26 +455,28 @@ func (self *OfnetAgent) RemoveVtepPort(portNo uint32, remoteIp net.IP) error {
 	return self.datapath.RemoveVtepPort(portNo, remoteIp)
 }
 
-// Add a vlan.
-// This is mainly used for mapping vlan id to Vxlan VNI
+// Add a Network.
+// This is mainly used for mapping vlan id to Vxlan VNI and add gateway for network
 func (self *OfnetAgent) AddNetwork(vlanId uint16, vni uint32, Gw string) error {
 	// store it in DB
 	self.vlanVniMap[vlanId] = &vni
 	self.vniVlanMap[vni] = &vlanId
-
-	// Call the datapath
-	epreg := &OfnetEndpoint{
-		EndpointID:   Gw,
-		EndpointType: "internal",
-		IpAddr:       net.ParseIP(Gw),
-		IpMask:       net.ParseIP("255.255.255.255"),
-		VrfId:        0, // FIXME set VRF correctly
-		Vlan:         1,
-		PortNo:       0,
-		Timestamp:    time.Now(),
+	if Gw != "" {
+		// Call the datapath
+		epreg := &OfnetEndpoint{
+			EndpointID:   Gw,
+			EndpointType: "internal",
+			IpAddr:       net.ParseIP(Gw),
+			IpMask:       net.ParseIP("255.255.255.255"),
+			VrfId:        0, // FIXME set VRF correctly
+			Vlan:         1,
+			PortNo:       0,
+			Timestamp:    time.Now(),
+		}
+		self.endpointDb[Gw] = epreg
+		return self.datapath.AddVlan(vlanId, vni)
 	}
-	self.endpointDb[Gw] = epreg
-	return self.datapath.AddVlan(vlanId, vni)
+	return nil
 
 }
 
@@ -566,6 +573,12 @@ func (self *OfnetAgent) DummyRpc(arg *string, ret *bool) error {
 	return nil
 }
 
+/*
+Bgp serve routine does the following:
+1) Creates inb01 router port
+2) Add MyBgp endpoint
+3) Kicks off routines to monitor route updates and peer state
+*/
 func (self *OfnetAgent) Serve() error {
 	time.Sleep(5 * time.Second)
 
@@ -585,7 +598,7 @@ func (self *OfnetAgent) Serve() error {
 		Pattrs: make([][]byte, 0),
 	}
 
-	routerId := self.routerIP //d.config.Bgp.Global.GlobalConfig.RouterId.String()
+	routerId := self.routerIP
 	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(32), routerId).Serialize()
 	n, _ := bgp.NewPathAttributeNextHop("0.0.0.0").Serialize()
 	path.Pattrs = append(path.Pattrs, n)
@@ -603,7 +616,10 @@ func (self *OfnetAgent) Serve() error {
 	intf, _ := net.InterfaceByName("inb01")
 	ofPortno, _ := self.ovsDriver.GetOfpPortNo("inb01")
 
-	fmt.Println("Creating BGP PEER ENDPOINT !!!!!!!!!!!")
+	if intf == nil || ofPortno == 0 {
+		log.Errorf("Error fetching inb01 information", intf, ofPortno)
+	}
+
 	epreg := &OfnetEndpoint{
 		EndpointID:   routerId,
 		EndpointType: "internal-bgp",
@@ -625,14 +641,15 @@ func (self *OfnetAgent) Serve() error {
 	//Add bgp router id as well
 	bgpGlobalCfg := bgpconf.Global{}
 	SetDefaultGlobalConfigValues(&bgpGlobalCfg)
-	//bgpGlobalCfg = bgpconf.Global{GlobalConfig: bgpconf.GlobalConfig{RouterId: net.ParseIP(routerId), As: 65002}}
 	bgpGlobalCfg.GlobalConfig.RouterId = net.ParseIP(routerId)
 	bgpGlobalCfg.GlobalConfig.As = 65002
 	self.bgpServer.SetGlobalType(bgpGlobalCfg)
 
 	self.advPathCh <- path
 
+	//monitor route updates from peer
 	go self.monitorBest()
+	//monitor peer state
 	go self.monitorPeer()
 
 	for {
@@ -651,6 +668,7 @@ func (self *OfnetAgent) Serve() error {
 	}
 }
 
+//monitorBest monitors for route updates/changes form peer
 func (self *OfnetAgent) monitorBest() error {
 
 	timeout := grpc.WithTimeout(time.Second)
@@ -686,12 +704,12 @@ func (self *OfnetAgent) monitorBest() error {
 	return nil
 }
 
+//Modrib receives route updates from BGP server and adds the endpoint
 func (self *OfnetAgent) modRib(path *api.Path) error {
 	var nlri bgp.AddrPrefixInterface
 	var nextHop string
 	var macAddrStr string
 	var portNo uint32
-
 	if len(path.Nlri) > 0 {
 		nlri = &bgp.IPAddrPrefix{}
 		err := nlri.DecodeFromBytes(path.Nlri)
@@ -725,19 +743,17 @@ func (self *OfnetAgent) modRib(path *api.Path) error {
 	}
 
 	endpointIPNet, _ := netlink.ParseIPNet(nlri.String())
-	fmt.Println("HERE is the ENDPOINT IP ")
-	fmt.Println(endpointIPNet)
-	fmt.Println("HERE is the Nexthop IP ")
-	fmt.Println(nextHop)
+	log.Infof("Bgp Rib Received endpoint update for %v , with nexthop %v", endpointIPNet, nextHop)
 
 	//check if bgp published a route local to the host
 	epid := endpointIPNet.IP.Mask(endpointIPNet.Mask).String()
-	//Check if the route is local
 
+	//Check if the route is local
 	if nextHop == self.routerIP {
 		log.Info("This is a local route skipping endpoint create! ")
 		return nil
 	}
+
 	if self.endpointDb[nextHop] == nil {
 		//the nexthop is not the directly connected eBgp peer
 		macAddrStr = ""
@@ -774,10 +790,14 @@ func (self *OfnetAgent) modRib(path *api.Path) error {
 		}
 	} else {
 		log.Info("Received route withdraw from BGP for ", endpointIPNet)
+		endpoint := self.getEndpointByIp(endpointIPNet.IP)
+		self.datapath.RemoveEndpoint(endpoint)
+		delete(self.endpointDb, endpoint.EndpointID)
 	}
 	return nil
 }
 
+//CreateBgpServer creates and starts a bgp server and correspoinding grpc server
 func CreateBgpServer() (bgpServer *bgpserver.BgpServer, grpcServer *bgpserver.Server) {
 	bgpServer = bgpserver.NewBgpServer(bgp.BGP_PORT)
 	if bgpServer == nil {
@@ -793,12 +813,51 @@ func CreateBgpServer() (bgpServer *bgpserver.BgpServer, grpcServer *bgpserver.Se
 	return
 }
 
+//DeleteBgpNeighbors deletes bgp neighbor for the host
 func (self *OfnetAgent) DeleteBgpNeighbors() error {
 
-	//As a part of delete bgp neighbors
-	//Search for BGP peer.
-	//Delete the peer from bgp , delete endpoint info for peer
-	//Finally delete all routes learnt on the uplink port.
+	/*As a part of delete bgp neighbors
+	1) Search for BGP peer and remove from Bgp.
+	2) Delete endpoint info for peer
+	3) Finally delete all routes learnt on the nexthop bgp port.
+	4) Mark the routes learn via json rpc as unresolved
+	*/
+
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	client := api.NewGobgpApiClient(conn)
+	if client == nil {
+
+	}
+	arg := &api.Arguments{Name: self.myBgpPeer}
+
+	peer, err := client.GetNeighbor(context.Background(), arg)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	log.Infof("Deleteing Bgp peer from Bgp server")
+	p := bgpconf.Neighbor{}
+	SetNeighborConfigValues(&p)
+
+	p.NeighborAddress = net.ParseIP(peer.Conf.NeighborAddress)
+	p.NeighborConfig.NeighborAddress = net.ParseIP(peer.Conf.NeighborAddress)
+	p.NeighborConfig.PeerAs = uint32(peer.Conf.PeerAs)
+	//FIX ME set ipv6 depending on peerip (for v6 BGP)
+	p.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
+		bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"}}
+	self.bgpServer.SetBmpConfig(bgpconf.BmpServers{
+		BmpServerList: []bgpconf.BmpServer{},
+	})
+	self.bgpServer.PeerDelete(p)
+	bgpEndpoint := self.getEndpointByIp(net.ParseIP(self.myBgpPeer))
+	self.datapath.RemoveEndpoint(bgpEndpoint)
+	delete(self.endpointDb, self.myBgpPeer)
+
 	uplink, _ := self.ovsDriver.GetOfpPortNo(self.vlanIntf)
 
 	for _, endpoint := range self.endpointDb {
@@ -812,43 +871,6 @@ func (self *OfnetAgent) DeleteBgpNeighbors() error {
 				self.datapath.AddEndpoint(endpoint)
 			} else if endpoint.EndpointType == "external" {
 				delete(self.endpointDb, endpoint.EndpointID)
-			} else if endpoint.EndpointType == "external-bgp" {
-
-				timeout := grpc.WithTimeout(time.Second)
-				conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer conn.Close()
-				client := api.NewGobgpApiClient(conn)
-				if client == nil {
-
-				}
-				arg := &api.Arguments{Name: endpoint.EndpointID}
-
-				peer, err := client.GetNeighbor(context.Background(), arg)
-				if err != nil {
-					fmt.Println(err)
-					return err
-				}
-				log.Infof("Deleteing Bgp peer from Bgp server")
-				p := bgpconf.Neighbor{}
-				SetNeighborConfigValues(&p)
-				//	p = bgpconf.Neighbor{
-				//		NeighborAddress: net.ParseIP(peer),
-				//		NeighborConfig: bgpconf.NeighborConfig{NeighborAddress: net.ParseIP(peer),
-				//			PeerAs: uint32(peerAs)},
-				//	}
-				p.NeighborAddress = net.ParseIP(peer.Conf.NeighborAddress)
-				p.NeighborConfig.NeighborAddress = net.ParseIP(peer.Conf.NeighborAddress)
-				p.NeighborConfig.PeerAs = uint32(peer.Conf.PeerAs)
-				//FIX ME set ipv6 depending on peerip (for v6 BGP)
-				p.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
-					bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"}}
-				self.bgpServer.SetBmpConfig(bgpconf.BmpServers{
-					BmpServerList: []bgpconf.BmpServer{},
-				})
-				self.bgpServer.PeerDelete(p)
 			}
 		}
 	}
@@ -856,67 +878,61 @@ func (self *OfnetAgent) DeleteBgpNeighbors() error {
 
 }
 
-func (self *OfnetAgent) AddBgpNeighbors(As string, neighbors []string) error {
+//AddBgpNeighbors add bgp neighbor
+func (self *OfnetAgent) AddBgpNeighbors(As string, peer string) error {
 
 	var policyConfig bgpconf.RoutingPolicy
-	//policyConfig = bgpconf.Plicy{}
 	peerAs, _ := strconv.Atoi(As)
-	for _, peer := range neighbors {
-		p := bgpconf.Neighbor{}
-		SetNeighborConfigValues(&p)
-		//	p = bgpconf.Neighbor{
-		//		NeighborAddress: net.ParseIP(peer),
-		//		NeighborConfig: bgpconf.NeighborConfig{NeighborAddress: net.ParseIP(peer),
-		//			PeerAs: uint32(peerAs)},
-		//	}
-		p.NeighborAddress = net.ParseIP(peer)
-		p.NeighborConfig.NeighborAddress = net.ParseIP(peer)
-		p.NeighborConfig.PeerAs = uint32(peerAs)
+	p := bgpconf.Neighbor{}
+	SetNeighborConfigValues(&p)
+	p.NeighborAddress = net.ParseIP(peer)
+	p.NeighborConfig.NeighborAddress = net.ParseIP(peer)
+	p.NeighborConfig.PeerAs = uint32(peerAs)
 
-		//FIX ME set ipv6 depending on peerip (for v6 BGP)
-		p.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
-			bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"}}
-		log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
-		self.bgpServer.SetBmpConfig(bgpconf.BmpServers{
-			BmpServerList: []bgpconf.BmpServer{},
-		})
-		log.Infof("Peer %v is added   3 ", p.NeighborConfig.NeighborAddress)
-		self.bgpServer.PeerAdd(p)
-		//	if policyConfig == nil {
-		//policyConfig = &newConfig.Policy
-		self.bgpServer.SetPolicy(policyConfig)
-		//	} else {
-		//if bgpconf.CheckPolicyDifference(policyConfig, &newConfig.Policy) {
-		//	log.Info("Policy config is updated")
-		//	bgpServer.UpdatePolicy(newConfig.Policy)
-		//}
-		//	}
+	//FIX ME set ipv6 depending on peerip (for v6 BGP)
+	p.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
+		bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"}}
+	log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
+	self.bgpServer.SetBmpConfig(bgpconf.BmpServers{
+		BmpServerList: []bgpconf.BmpServer{},
+	})
+	log.Infof("Peer %v is added   3 ", p.NeighborConfig.NeighborAddress)
+	self.bgpServer.PeerAdd(p)
+	//	if policyConfig == nil {
+	//policyConfig = &newConfig.Policy
+	self.bgpServer.SetPolicy(policyConfig)
+	//	} else {
+	//if bgpconf.CheckPolicyDifference(policyConfig, &newConfig.Policy) {
+	//	log.Info("Policy config is updated")
+	//	bgpServer.UpdatePolicy(newConfig.Policy)
+	//}
+	//	}
 
-		log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
-		epreg := &OfnetEndpoint{
-			EndpointID:   peer,
-			EndpointType: "external-bgp",
-			IpAddr:       net.ParseIP(peer),
-			IpMask:       net.ParseIP("255.255.255.255"),
-			VrfId:        0, // FIXME set VRF correctly
-			Vlan:         1,
-			Timestamp:    time.Now(),
-		}
-
-		// Install the endpoint in datapath
-		// First, add the endpoint to local routing table
-		self.endpointDb[epreg.EndpointID] = epreg
-		err := self.datapath.AddEndpoint(epreg)
-
-		if err != nil {
-			log.Errorf("ABHI : OFNETAGENT Error adding endpoint: {%+v}. Err: %v", epreg, err)
-			return err
-		}
-
+	log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
+	epreg := &OfnetEndpoint{
+		EndpointID:   peer,
+		EndpointType: "external-bgp",
+		IpAddr:       net.ParseIP(peer),
+		IpMask:       net.ParseIP("255.255.255.255"),
+		VrfId:        0, // FIXME set VRF correctly
+		Vlan:         1,
+		Timestamp:    time.Now(),
 	}
+
+	// Install the endpoint in datapath
+	// First, add the endpoint to local routing table
+	self.endpointDb[epreg.EndpointID] = epreg
+	err := self.datapath.AddEndpoint(epreg)
+
+	if err != nil {
+		log.Errorf("Error adding endpoint: {%+v}. Err: %v", epreg, err)
+		return err
+	}
+	self.myBgpPeer = peer
 	return nil
 }
 
+//SetDefaultGlobalConfigValues sets the default global configs for bgp
 func SetDefaultGlobalConfigValues(bt *bgpconf.Global) error {
 
 	bt.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
@@ -938,6 +954,7 @@ func SetDefaultGlobalConfigValues(bt *bgpconf.Global) error {
 	return nil
 }
 
+//SetNeighborConfigValues sets the default neighbor configs for bgp
 func SetNeighborConfigValues(neighbor *bgpconf.Neighbor) error {
 
 	timerConfig := neighbor.Timers.TimersConfig
@@ -951,6 +968,7 @@ func SetNeighborConfigValues(neighbor *bgpconf.Neighbor) error {
 	return nil
 }
 
+// monitorPeer is used to monitor the bgp peer state
 func (self *OfnetAgent) monitorPeer() error {
 
 	var oldAdminState, oldState string
@@ -983,7 +1001,11 @@ func (self *OfnetAgent) monitorPeer() error {
 		fmt.Printf("[NEIGH] %s fsm: %s admin: %s\n", s.Conf.NeighborAddress, s.Info.BgpState, s.Info.AdminState)
 		if oldState == "BGP_FSM_ESTABLISHED" && oldAdminState == "ADMIN_STATE_UP" {
 			uplink, _ := self.ovsDriver.GetOfpPortNo(self.vlanIntf)
-			//walk all external endpoints in the endpointDB and remove the resolution
+			/*If the state changed from being established to idle or active:
+			   1) delete all endpoints learnt via bgp Peer
+				 2) mark routes pointing to the bgp nexthop as unresolved
+				 3) mark the bgp peer reachbility as unresolved
+			*/
 			for _, endpoint := range self.endpointDb {
 				if endpoint.PortNo == uplink {
 					self.datapath.RemoveEndpoint(endpoint)
@@ -999,8 +1021,6 @@ func (self *OfnetAgent) monitorPeer() error {
 						// bgp peer endpoint
 						endpoint.PortNo = 0
 						self.endpointDb[endpoint.EndpointID] = endpoint
-						//We readd unresolved endpoints that were learnt via
-						//json rpc
 						self.datapath.AddEndpoint(endpoint)
 					}
 				}
@@ -1011,3 +1031,33 @@ func (self *OfnetAgent) monitorPeer() error {
 	}
 	return nil
 }
+
+/*ShowRib api to dump BGP RIB
+func (self *OfnetAgent) ShowRib() error {
+
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	client := api.NewGobgpApiClient(conn)
+	if client == nil {
+
+	}
+
+	arg := &api.Table{
+		Type:   api.Resource_GLOBAL,
+		Family: uint32(bgp.RF_IPv4_UC),
+	}
+
+	rib, err := client.GetRib(context.Background(), arg)
+	if err != nil {
+		fmt.Println("returnin Error", err)
+		return err
+	}
+
+	return nil
+
+}
+*/

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -587,7 +587,8 @@ Bgp serve routine does the following:
 3) Kicks off routines to monitor route updates and peer state
 */
 func (self *OfnetAgent) Serve() error {
-	time.Sleep(5 * time.Second)
+	//time.Sleep(5 * time.Second)
+	self.WaitForSwitchConnection()
 
 	self.modRibCh = make(chan *api.Path, 16)
 	self.advPathCh = make(chan *api.Path, 16)
@@ -647,7 +648,7 @@ func (self *OfnetAgent) Serve() error {
 	// Add the endpoint to local routing table
 	self.endpointDb[routerId] = epreg
 	self.localEndpointDb[epreg.PortNo] = epreg
-
+	fmt.Println(epreg)
 	err = self.datapath.AddLocalEndpoint(*epreg)
 
 	//Add bgp router id as well

--- a/ofnetBgp.go
+++ b/ofnetBgp.go
@@ -15,18 +15,16 @@ limitations under the License.
 package ofnet
 
 import (
+	"container/list"
 	"errors"
 	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"io"
 	"net"
 	"os/exec"
 	"strconv"
 	"time"
 
-	"container/list"
-	log "github.com/Sirupsen/logrus"
-
-	"github.com/contiv/ofnet/libpkt"
 	api "github.com/osrg/gobgp/api"
 	bgpconf "github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet"
@@ -684,7 +682,6 @@ func setNeighborConfigValues(neighbor *bgpconf.Neighbor) error {
 	return nil
 }
 
-/*
 func (self *OfnetBgp) sendArp() {
 
 	//Get the Mac of the vlan intf
@@ -701,11 +698,13 @@ func (self *OfnetBgp) sendArp() {
 		bMac, _ := net.ParseMAC("FF:FF:FF:FF:FF:FF")
 		zeroMac, _ := net.ParseMAC("00:00:00:00:00:00")
 
+		srcIP := net.ParseIP(self.routerIP)
+		dstIP := net.ParseIP(self.myBgpPeer)
 		arpReq, _ := protocol.NewARP(protocol.Type_Request)
 		arpReq.HWSrc = intf.HardwareAddr
-		arpReq.IPSrc = net.ParseIP(self.routerIP)
+		arpReq.IPSrc = srcIP
 		arpReq.HWDst = zeroMac
-		arpReq.IPDst = net.ParseIP(self.myBgpPeer)
+		arpReq.IPDst = dstIP
 
 		log.Infof("Sending ARP Request: %+v", arpReq)
 
@@ -730,30 +729,7 @@ func (self *OfnetBgp) sendArp() {
 		time.Sleep(1800 * time.Second)
 	}
 }
-*/
 
-func (self *OfnetBgp) sendArp() {
-	time.Sleep(5 * time.Second)
-	for {
-		if self.myBgpPeer == "" {
-			return
-		}
-
-		arpLayer := &libpkt.ArpLayer{
-			SourceProtAddress: self.routerIP,
-			DstProtAddress:    self.myBgpPeer,
-			Operation:         1,
-			SourceHwAddress:   intf.HardwareAddr.String(),
-			DstHwAddress:      "00:00:00:00:00:00",
-		}
-
-		pkt := &libpkt.Packet{SrcMAC: intf.HardwareAddr.String(), DstMAC: "FF:FF:FF:FF:FF:FF",
-			Arp: arpLayer}
-		libpkt.SendPacket(self.agent.ovsDriver, self.vlanIntf, pkt, 1)
-		time.Sleep(1800 * time.Second)
-	}
-
-}
 func (self *OfnetBgp) ModifyProtoRib(path interface{}) {
 	self.modRibCh <- path.(*api.Path)
 }

--- a/ofnetBgp.go
+++ b/ofnetBgp.go
@@ -192,7 +192,7 @@ func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
 
 }
 
-//DeleteBgpNeighbors deletes bgp neighbor for the host
+//DeleteProtoNeighbor deletes bgp neighbor for the host
 func (self *OfnetBgp) DeleteProtoNeighbor() error {
 
 	/*As a part of delete bgp neighbors
@@ -251,7 +251,7 @@ func (self *OfnetBgp) DeleteProtoNeighbor() error {
 
 }
 
-//AddBgpNeighbors add bgp neighbor
+//AddProtoNeighbor adds bgp neighbor
 func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) error {
 
 	var policyConfig bgpconf.RoutingPolicy
@@ -304,6 +304,7 @@ func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) err
 	return nil
 }
 
+//GetRouterInfo returns the configured RouterInfo
 func (self *OfnetBgp) GetRouterInfo() *OfnetProtoRouterInfo {
 	routerInfo := &OfnetProtoRouterInfo{
 		ProtocolType: "bgp",
@@ -313,6 +314,7 @@ func (self *OfnetBgp) GetRouterInfo() *OfnetProtoRouterInfo {
 	return routerInfo
 }
 
+//AddLocalProtoRoute is used to add local endpoint to the protocol RIB
 func (self *OfnetBgp) AddLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error {
 
 	path := &api.Path{
@@ -368,6 +370,7 @@ func (self *OfnetBgp) AddLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error {
 	return nil
 }
 
+//DeleteLocalProtoRoute withdraws local endpoints from protocol RIB
 func (self *OfnetBgp) DeleteLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error {
 
 	path := &api.Path{

--- a/ofnetBgp.go
+++ b/ofnetBgp.go
@@ -1,0 +1,558 @@
+/***
+Copyright 2014 Cisco Systems Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ofnet
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"container/list"
+	log "github.com/Sirupsen/logrus"
+	api "github.com/osrg/gobgp/api"
+	bgpconf "github.com/osrg/gobgp/config"
+	"github.com/osrg/gobgp/packet"
+	bgpserver "github.com/osrg/gobgp/server"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+type OfnetBgp struct {
+	routerIP string      // virtual interface ip for bgp
+	vlanIntf string      // uplink port name
+	agent    *OfnetAgent // Pointer back to ofnet agent that owns this
+
+	//bgp resources
+	modRibCh   chan *api.Path //channel for route change notif
+	advPathCh  chan *api.Path
+	bgpServer  *bgpserver.BgpServer // bgp server instance
+	grpcServer *bgpserver.Server    // grpc server to talk to gobgp
+
+	myRouterMac   net.HardwareAddr //Router mac used for external proxy
+	myBgpPeer     string           // bgp neighbor
+	unresolvedEPs *list.List       // unresolved endpoint list
+}
+
+// Create a new vlrouter instance
+func NewOfnetBgp(agent *OfnetAgent, routerInfo []string) *OfnetBgp {
+
+	//Sanity checks
+	if agent == nil || agent.datapath == nil {
+		log.Errorf("Invilid OfnetAgent")
+		return nil
+	}
+
+	ofnetBgp := new(OfnetBgp)
+	// Keep a reference to the agent
+	ofnetBgp.agent = agent
+	if len(routerInfo) > 1 {
+		//Ensuring routerInfo is in ip format
+		if ok := net.ParseIP(routerInfo[0]); ok != nil {
+			ofnetBgp.routerIP = routerInfo[0]
+		} else {
+			log.Errorf("Error creating ofnetBgp")
+			return nil
+		}
+		ofnetBgp.vlanIntf = routerInfo[1]
+	}
+	ofnetBgp.bgpServer, ofnetBgp.grpcServer = createBgpServer()
+	//go routine to start gobgp server
+	go func() {
+		rInfo := OfnetProtoRouterInfo{ProtocolType: "bgp", RouterIP: ofnetBgp.routerIP}
+		err := ofnetBgp.StartProtoServer(rInfo)
+		if err != nil {
+			log.Errorf("protocol server finished with err: %s", err)
+		}
+	}()
+	return ofnetBgp
+}
+
+/*
+Bgp serve routine does the following:
+1) Creates inb01 router port
+2) Add MyBgp endpoint
+3) Kicks off routines to monitor route updates and peer state
+*/
+func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
+	time.Sleep(5 * time.Second)
+	self.agent.WaitForSwitchConnection()
+
+	self.modRibCh = make(chan *api.Path, 16)
+	self.advPathCh = make(chan *api.Path, 16)
+
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := api.NewGobgpApiClient(conn)
+	if client == nil {
+
+	}
+	path := &api.Path{
+		Pattrs: make([][]byte, 0),
+	}
+
+	if len(routerInfo.RouterIP) == 0 {
+		log.Errorf("Invalid router IP. Bgp service aborted")
+		return errors.New("Invalid router IP")
+	}
+	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(32), routerInfo.RouterIP).Serialize()
+	n, _ := bgp.NewPathAttributeNextHop("0.0.0.0").Serialize()
+	path.Pattrs = append(path.Pattrs, n)
+	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE).Serialize()
+	path.Pattrs = append(path.Pattrs, origin)
+
+	err = self.agent.ovsDriver.CreatePort("inb01", "internal", 1)
+	if err != nil {
+		log.Errorf("Error creating the port", err)
+		return err
+	}
+
+	cmd := exec.Command("ifconfig", "inb01", routerInfo.RouterIP+"/24")
+	cmd.Run()
+
+	intf, _ := net.InterfaceByName("inb01")
+	ofPortno, _ := self.agent.ovsDriver.GetOfpPortNo("inb01")
+
+	if intf == nil || ofPortno == 0 {
+		log.Errorf("Error fetching inb01 information", intf, ofPortno)
+		return errors.New("Unable to fetch inb01 info")
+	}
+
+	epreg := &OfnetEndpoint{
+		EndpointID:   routerInfo.RouterIP,
+		EndpointType: "internal-bgp",
+		IpAddr:       net.ParseIP(routerInfo.RouterIP),
+		IpMask:       net.ParseIP("255.255.255.255"),
+		VrfId:        0,                          // FIXME set VRF correctly
+		MacAddrStr:   intf.HardwareAddr.String(), //link.Attrs().HardwareAddr.String(),
+		Vlan:         1,
+		PortNo:       ofPortno,
+		Timestamp:    time.Now(),
+	}
+	// Add the endpoint to local routing table
+	self.agent.endpointDb[routerInfo.RouterIP] = epreg
+	self.agent.localEndpointDb[epreg.PortNo] = epreg
+	fmt.Println(epreg)
+	err = self.agent.datapath.AddLocalEndpoint(*epreg)
+
+	//Add bgp router id as well
+	bgpGlobalCfg := &bgpconf.Global{}
+	SetDefaultGlobalConfigValues(bgpGlobalCfg)
+	bgpGlobalCfg.GlobalConfig.RouterId = net.ParseIP(routerInfo.RouterIP)
+	bgpGlobalCfg.GlobalConfig.As = 65002
+	self.bgpServer.SetGlobalType(*bgpGlobalCfg)
+
+	self.advPathCh <- path
+
+	//monitor route updates from peer
+	go self.monitorBest()
+	//monitor peer state
+	go self.monitorPeer()
+
+	for {
+		select {
+		case p := <-self.modRibCh:
+			err = self.modRib(p)
+			if err != nil {
+				log.Error("failed to mod rib: ", err)
+			}
+		case p := <-self.advPathCh:
+			//err = self.advPath(p)
+			if err != nil {
+				log.Error("failed to adv path: ", err, p)
+			}
+		}
+	}
+}
+
+//monitorBest monitors for route updates/changes form peer
+func (self *OfnetBgp) monitorBest() error {
+
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	client := api.NewGobgpApiClient(conn)
+	if client == nil {
+
+	}
+	arg := &api.Arguments{
+		Resource: api.Resource_GLOBAL,
+		Rf:       uint32(bgp.RF_IPv4_UC),
+	}
+
+	stream, err := client.MonitorBestChanged(context.Background(), arg)
+	if err != nil {
+		return err
+	}
+
+	for {
+		dst, err := stream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		self.modRibCh <- dst.Paths[0]
+	}
+	return nil
+}
+
+//Modrib receives route updates from BGP server and adds the endpoint
+func (self *OfnetBgp) modRib(path *api.Path) error {
+	var nlri bgp.AddrPrefixInterface
+	var nextHop string
+	var macAddrStr string
+	var portNo uint32
+	if len(path.Nlri) > 0 {
+		nlri = &bgp.IPAddrPrefix{}
+		err := nlri.DecodeFromBytes(path.Nlri)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, attr := range path.Pattrs {
+		p, err := bgp.GetPathAttribute(attr)
+		if err != nil {
+			return err
+		}
+
+		err = p.DecodeFromBytes(attr)
+		if err != nil {
+			return err
+		}
+
+		if p.GetType() == bgp.BGP_ATTR_TYPE_NEXT_HOP {
+			nextHop = p.(*bgp.PathAttributeNextHop).Value.String()
+			break
+		}
+	}
+	if nextHop == "0.0.0.0" {
+		return nil
+	}
+
+	if nlri == nil {
+		return fmt.Errorf("no nlri")
+	}
+
+	endpointIPNet, _ := netlink.ParseIPNet(nlri.String())
+	log.Infof("Bgp Rib Received endpoint update for %v , with nexthop %v",
+		endpointIPNet, nextHop)
+
+	//check if bgp published a route local to the host
+	epid := endpointIPNet.IP.Mask(endpointIPNet.Mask).String()
+
+	//Check if the route is local
+	if nextHop == self.routerIP {
+		log.Info("This is a local route skipping endpoint create! ")
+		return nil
+	}
+
+	if self.agent.endpointDb[nextHop] == nil {
+		//the nexthop is not the directly connected eBgp peer
+		macAddrStr = ""
+		portNo = 0
+	} else {
+		macAddrStr = self.agent.endpointDb[nextHop].MacAddrStr
+		portNo = self.agent.endpointDb[nextHop].PortNo
+	}
+
+	ipmask := net.ParseIP("255.255.255.255").Mask(endpointIPNet.Mask)
+
+	if path.IsWithdraw != true {
+		epreg := &OfnetEndpoint{
+			EndpointID:   epid,
+			EndpointType: "external",
+			IpAddr:       endpointIPNet.IP,
+			IpMask:       ipmask,
+			VrfId:        0, // FIXME set VRF correctly
+			MacAddrStr:   macAddrStr,
+			Vlan:         1,
+			OriginatorIp: self.agent.localIp,
+			PortNo:       portNo,
+			Timestamp:    time.Now(),
+		}
+
+		// Install the endpoint in datapath
+		// First, add the endpoint to local routing table
+		self.agent.endpointDb[epreg.EndpointID] = epreg
+		err := self.agent.datapath.AddEndpoint(epreg)
+		if err != nil {
+			log.Errorf("Error adding endpoint: {%+v}. Err: %v", epreg, err)
+			return err
+		}
+	} else {
+		log.Info("Received route withdraw from BGP for ", endpointIPNet)
+		endpoint := self.agent.getEndpointByIp(endpointIPNet.IP)
+		self.agent.datapath.RemoveEndpoint(endpoint)
+		delete(self.agent.endpointDb, endpoint.EndpointID)
+	}
+	return nil
+}
+
+//CreateBgpServer creates and starts a bgp server and correspoinding grpc server
+func createBgpServer() (bgpServer *bgpserver.BgpServer, grpcServer *bgpserver.Server) {
+	bgpServer = bgpserver.NewBgpServer(bgp.BGP_PORT)
+	if bgpServer == nil {
+		log.Errorf("Error creating bgp server")
+	}
+	go bgpServer.Serve()
+	// start grpc Server
+	grpcServer = bgpserver.NewGrpcServer(bgpserver.GRPC_PORT, bgpServer.GrpcReqCh)
+	if grpcServer == nil {
+		log.Errorf("Error creating bgp server")
+	}
+	go grpcServer.Serve()
+	return
+}
+
+//DeleteBgpNeighbors deletes bgp neighbor for the host
+func (self *OfnetBgp) DeleteProtoNeighbor() error {
+
+	/*As a part of delete bgp neighbors
+	1) Search for BGP peer and remove from Bgp.
+	2) Delete endpoint info for peer
+	3) Finally delete all routes learnt on the nexthop bgp port.
+	4) Mark the routes learn via json rpc as unresolved
+	*/
+
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	client := api.NewGobgpApiClient(conn)
+	if client == nil {
+
+	}
+	arg := &api.Arguments{Name: self.myBgpPeer}
+
+	peer, err := client.GetNeighbor(context.Background(), arg)
+	if err != nil {
+		log.Errorf("GetNeighbor failed ", err)
+		return err
+	}
+	log.Infof("Deleteing Bgp peer from Bgp server")
+	p := bgpconf.Neighbor{}
+	SetNeighborConfigValues(&p)
+
+	p.NeighborAddress = net.ParseIP(peer.Conf.NeighborAddress)
+	p.NeighborConfig.NeighborAddress = net.ParseIP(peer.Conf.NeighborAddress)
+	p.NeighborConfig.PeerAs = uint32(peer.Conf.PeerAs)
+	//FIX ME set ipv6 depending on peerip (for v6 BGP)
+	p.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
+		bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"}}
+	self.bgpServer.SetBmpConfig(bgpconf.BmpServers{
+		BmpServerList: []bgpconf.BmpServer{},
+	})
+	self.bgpServer.PeerDelete(p)
+	bgpEndpoint := self.agent.getEndpointByIp(net.ParseIP(self.myBgpPeer))
+	self.agent.datapath.RemoveEndpoint(bgpEndpoint)
+	delete(self.agent.endpointDb, self.myBgpPeer)
+
+	uplink, _ := self.agent.ovsDriver.GetOfpPortNo(self.vlanIntf)
+
+	for _, endpoint := range self.agent.endpointDb {
+		if endpoint.PortNo == uplink {
+			self.agent.datapath.RemoveEndpoint(endpoint)
+			if endpoint.EndpointType == "internal" {
+				endpoint.PortNo = 0
+				self.agent.endpointDb[endpoint.EndpointID] = endpoint
+				//We readd unresolved endpoints that were learnt via
+				//etcd
+				self.agent.datapath.AddEndpoint(endpoint)
+			} else if endpoint.EndpointType == "external" {
+				delete(self.agent.endpointDb, endpoint.EndpointID)
+			}
+		}
+	}
+	return nil
+
+}
+
+//AddBgpNeighbors add bgp neighbor
+func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) error {
+
+	var policyConfig bgpconf.RoutingPolicy
+	peerAs, _ := strconv.Atoi(neighborInfo.As)
+	p := &bgpconf.Neighbor{}
+	SetNeighborConfigValues(p)
+	p.NeighborAddress = net.ParseIP(neighborInfo.NeighborIP)
+	p.NeighborConfig.NeighborAddress = net.ParseIP(neighborInfo.NeighborIP)
+	p.NeighborConfig.PeerAs = uint32(peerAs)
+	//FIX ME set ipv6 depending on peerip (for v6 BGP)
+	p.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
+		bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"}}
+	log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
+	self.bgpServer.SetBmpConfig(bgpconf.BmpServers{
+		BmpServerList: []bgpconf.BmpServer{},
+	})
+	log.Infof("Peer %v is added   3 ", p.NeighborConfig.NeighborAddress)
+	self.bgpServer.PeerAdd(*p)
+	//	if policyConfig == nil {
+	//policyConfig = &newConfig.Policy
+	self.bgpServer.SetPolicy(policyConfig)
+	//	} else {
+	//if bgpconf.CheckPolicyDifference(policyConfig, &newConfig.Policy) {
+	//	log.Info("Policy config is updated")
+	//	bgpServer.UpdatePolicy(newConfig.Policy)
+	//}
+	//	}
+
+	log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
+	epreg := &OfnetEndpoint{
+		EndpointID:   neighborInfo.NeighborIP,
+		EndpointType: "external-bgp",
+		IpAddr:       net.ParseIP(neighborInfo.NeighborIP),
+		IpMask:       net.ParseIP("255.255.255.255"),
+		VrfId:        0, // FIXME set VRF correctly
+		Vlan:         1,
+		Timestamp:    time.Now(),
+	}
+
+	// Install the endpoint in datapath
+	// First, add the endpoint to local routing table
+	self.agent.endpointDb[epreg.EndpointID] = epreg
+	err := self.agent.datapath.AddEndpoint(epreg)
+
+	if err != nil {
+		log.Errorf("Error adding endpoint: {%+v}. Err: %v", epreg, err)
+		return err
+	}
+	self.myBgpPeer = neighborInfo.NeighborIP
+	return nil
+}
+
+//SetDefaultGlobalConfigValues sets the default global configs for bgp
+func SetDefaultGlobalConfigValues(bt *bgpconf.Global) error {
+
+	bt.AfiSafis.AfiSafiList = []bgpconf.AfiSafi{
+		bgpconf.AfiSafi{AfiSafiName: "ipv4-unicast"},
+		bgpconf.AfiSafi{AfiSafiName: "ipv6-unicast"},
+		bgpconf.AfiSafi{AfiSafiName: "l3vpn-ipv4-unicast"},
+		bgpconf.AfiSafi{AfiSafiName: "l3vpn-ipv6-unicast"},
+		bgpconf.AfiSafi{AfiSafiName: "l2vpn-evpn"},
+		bgpconf.AfiSafi{AfiSafiName: "encap"},
+		bgpconf.AfiSafi{AfiSafiName: "rtc"},
+		bgpconf.AfiSafi{AfiSafiName: "ipv4-flowspec"},
+		bgpconf.AfiSafi{AfiSafiName: "l3vpn-ipv4-flowspec"},
+		bgpconf.AfiSafi{AfiSafiName: "ipv6-flowspec"},
+		bgpconf.AfiSafi{AfiSafiName: "l3vpn-ipv6-flowspec"},
+	}
+	bt.MplsLabelRange.MinLabel = bgpconf.DEFAULT_MPLS_LABEL_MIN
+	bt.MplsLabelRange.MaxLabel = bgpconf.DEFAULT_MPLS_LABEL_MAX
+
+	return nil
+}
+
+//SetNeighborConfigValues sets the default neighbor configs for bgp
+func SetNeighborConfigValues(neighbor *bgpconf.Neighbor) error {
+
+	neighbor.Timers.TimersConfig.ConnectRetry = float64(bgpconf.DEFAULT_CONNECT_RETRY)
+	neighbor.Timers.TimersConfig.HoldTime = float64(bgpconf.DEFAULT_HOLDTIME)
+	neighbor.Timers.TimersConfig.KeepaliveInterval = float64(bgpconf.DEFAULT_HOLDTIME / 3)
+	neighbor.Timers.TimersConfig.IdleHoldTimeAfterReset =
+		float64(bgpconf.DEFAULT_IDLE_HOLDTIME_AFTER_RESET)
+	//FIX ME need to check with global peer to set internal or external
+	neighbor.NeighborConfig.PeerType = bgpconf.PEER_TYPE_EXTERNAL
+	neighbor.Transport.TransportConfig.PassiveMode = false
+	return nil
+}
+
+// monitorPeer is used to monitor the bgp peer state
+func (self *OfnetBgp) monitorPeer() error {
+
+	var oldAdminState, oldState string
+
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	client := api.NewGobgpApiClient(conn)
+	if client == nil {
+
+	}
+	arg := &api.Arguments{}
+
+	stream, err := client.MonitorPeerState(context.Background(), arg)
+	if err != nil {
+		log.Errorf("MonitorPeerState failed ", err)
+		return err
+	}
+	for {
+		s, err := stream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			log.Errorf("MonitorPeerState stream failed :", err)
+			break
+		}
+		fmt.Printf("[NEIGH] %s fsm: %s admin: %s\n", s.Conf.NeighborAddress,
+			s.Info.BgpState, s.Info.AdminState)
+		if oldState == "BGP_FSM_ESTABLISHED" && oldAdminState == "ADMIN_STATE_UP" {
+			uplink, _ := self.agent.ovsDriver.GetOfpPortNo(self.vlanIntf)
+			/*If the state changed from being established to idle or active:
+			   1) delete all endpoints learnt via bgp Peer
+				 2) mark routes pointing to the bgp nexthop as unresolved
+				 3) mark the bgp peer reachbility as unresolved
+			*/
+			for _, endpoint := range self.agent.endpointDb {
+				if endpoint.PortNo == uplink {
+					self.agent.datapath.RemoveEndpoint(endpoint)
+					if endpoint.EndpointType == "internal" {
+						endpoint.PortNo = 0
+						self.agent.endpointDb[endpoint.EndpointID] = endpoint
+						//We readd unresolved endpoints that were learnt via
+						//json rpc
+						self.agent.datapath.AddEndpoint(endpoint)
+					} else if endpoint.EndpointType == "external" {
+						delete(self.agent.endpointDb, endpoint.EndpointID)
+					} else if endpoint.EndpointType == "external-bgp" {
+						// bgp peer endpoint
+						endpoint.PortNo = 0
+						self.agent.endpointDb[endpoint.EndpointID] = endpoint
+						self.agent.datapath.AddEndpoint(endpoint)
+					}
+				}
+			}
+		}
+		oldState = s.Info.BgpState
+		oldAdminState = s.Info.AdminState
+	}
+	return nil
+}
+
+func (self *OfnetBgp) GetRouterInfo() *OfnetProtoRouterInfo {
+	routerInfo := &OfnetProtoRouterInfo{
+		ProtocolType: "bgp",
+		RouterIP:     self.routerIP,
+		VlanIntf:     self.vlanIntf,
+	}
+	return routerInfo
+}

--- a/ofnetMaster.go
+++ b/ofnetMaster.go
@@ -103,6 +103,20 @@ func (self *OfnetMaster) RegisterNode(hostInfo *OfnetNode, ret *bool) error {
 		}
 	}
 
+	// Send all existing policy rules to the new node
+	for _, rule := range self.policyDb {
+			var resp bool
+
+			log.Infof("Sending rule: %+v to node %s:%d", rule, node.HostAddr, node.HostPort)
+
+			client := rpcHub.Client(node.HostAddr, node.HostPort)
+			err := client.Call("PolicyAgent.AddRule", rule, &resp)
+			if err != nil {
+				log.Errorf("Error adding rule to %s. Err: %v", node.HostAddr, err)
+				return err
+			}
+	}
+
 	return nil
 }
 

--- a/ofnetMaster.go
+++ b/ofnetMaster.go
@@ -142,7 +142,6 @@ func (self *OfnetMaster) EndpointAdd(ep *OfnetEndpoint, ret *bool) error {
 
 	// Publish it to all agents except where it came from
 	for _, node := range self.agentDb {
-		log.Infof("For loop")
 		if node.HostAddr != ep.OriginatorIp.String() {
 			var resp bool
 

--- a/ofnetPolicy.go
+++ b/ofnetPolicy.go
@@ -64,7 +64,7 @@ func (self *PolicyAgent) SwitchConnected(sw *ofctrl.OFSwitch) {
 	// Keep a reference to the switch
 	self.ofSwitch = sw
 
-	log.Infof("Switch connected(vrouter). installing flows")
+	log.Infof("Switch connected(policyAgent).")
 }
 
 // Handle switch disconnected notification

--- a/ofnetPolicy.go
+++ b/ofnetPolicy.go
@@ -224,7 +224,7 @@ func (self *PolicyAgent) AddRule(rule *OfnetPolicyRule, ret *bool) error {
 
 	// Install the rule in policy table
 	ruleFlow, err := self.policyTable.NewFlow(ofctrl.FlowMatch{
-		Priority:     FLOW_MATCH_PRIORITY,
+		Priority:     uint16(FLOW_POLICY_PRIORITY_OFFSET + rule.Priority),
 		Ethertype:    0x0800,
 		IpDa:         ipDa,
 		IpDaMask:     ipDaMask,

--- a/ofnetPolicy_test.go
+++ b/ofnetPolicy_test.go
@@ -68,7 +68,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	ofnetAgent.WaitForSwitchConnection()
 
 	// Create a vlan for the endpoint
-	ofnetAgent.AddVlan(1, 1)
+	ofnetAgent.AddNetwork(1, 1, "")
 
 	macAddr, _ := net.ParseMAC("00:01:02:03:04:05")
 	endpoint := EndpointInfo{

--- a/ofnetPolicy_test.go
+++ b/ofnetPolicy_test.go
@@ -16,25 +16,44 @@ limitations under the License.
 package ofnet
 
 import (
+	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/ofnet/ovsdbDriver"
 )
 
-func TestPolicy(t *testing.T) {
-	rpcPort := uint16(9101)
-	ovsPort := uint16(9151)
-	lclIp := net.ParseIP("10.10.10.10")
-	ofnetAgent, err := NewOfnetAgent("vrouter", lclIp, rpcPort, ovsPort)
+func TestPolicyAddDelete(t *testing.T) {
+	var resp bool
+	rpcPort := uint16(9600)
+	ovsPort := uint16(9601)
+	lclIP := net.ParseIP("10.10.10.10")
+	ofnetAgent, err := NewOfnetAgent("vrouter", lclIP, rpcPort, ovsPort)
 	if err != nil {
 		t.Fatalf("Error creating ofnet agent. Err: %v", err)
 	}
 
+	defer func() { ofnetAgent.Delete() }()
+
 	// Override MyAddr to local host
 	ofnetAgent.MyAddr = "127.0.0.1"
+
+	// Create a Master
+	ofnetMaster := NewOfnetMaster(uint16(9602))
+
+	defer func() { ofnetMaster.Delete() }()
+
+	masterInfo := OfnetNode{
+		HostAddr: "127.0.0.1",
+		HostPort: uint16(9602),
+	}
+
+	// connect vrtr agent to master
+	err = ofnetAgent.AddMaster(&masterInfo, &resp)
+	if err != nil {
+		t.Errorf("Error adding master %+v. Err: %v", masterInfo, err)
+	}
 
 	log.Infof("Created vrouter ofnet agent: %v", ofnetAgent)
 
@@ -45,26 +64,31 @@ func TestPolicy(t *testing.T) {
 		t.Fatalf("Error adding controller to ovs: %s", brName)
 	}
 
-	// Wait for 10sec for switch to connect to controller
-	time.Sleep(10 * time.Second)
+	defer func() { ovsDriver.DeleteBridge(brName) }()
 
-	// create policy agent
-	policyAgent := NewPolicyAgent(ofnetAgent, ofnetAgent.ofSwitch)
+	// Wait for switch to connect to controller
+	ofnetAgent.WaitForSwitchConnection()
 
-	// Init tables
-	policyAgent.InitTables(IP_TBL_ID)
+	// Create a vlan for the endpoint
+	ofnetAgent.AddVlan(1, 1)
+
+	macAddr, _ := net.ParseMAC("00:01:02:03:04:05")
+	endpoint := EndpointInfo{
+		EndpointGroup: 100,
+		PortNo:        12,
+		MacAddr:       macAddr,
+		Vlan:          1,
+		IpAddr:        net.ParseIP("10.2.2.2"),
+	}
+
+	log.Infof("Adding Local endpoint: %+v", endpoint)
 
 	// Add an Endpoint
-	err = policyAgent.AddEndpoint(&OfnetEndpoint{
-		EndpointID:    "1234",
-		EndpointGroup: 100,
-		IpAddr:        net.ParseIP("10.10.10.10"),
-	})
+	err = ofnetAgent.AddLocalEndpoint(endpoint)
 	if err != nil {
 		t.Errorf("Error adding endpoint. Err: %v", err)
 	}
 
-	var resp bool
 	tcpRule := &OfnetPolicyRule{
 		RuleId:           "tcpRule",
 		SrcEndpointGroup: 100,
@@ -76,8 +100,10 @@ func TestPolicy(t *testing.T) {
 		SrcPort:          200,
 	}
 
+	log.Infof("Adding rule: %+v", tcpRule)
+
 	// Add a policy
-	err = policyAgent.AddRule(tcpRule, &resp)
+	err = ofnetMaster.AddRule(tcpRule)
 	if err != nil {
 		t.Errorf("Error installing tcpRule {%+v}. Err: %v", tcpRule, err)
 	}
@@ -93,13 +119,87 @@ func TestPolicy(t *testing.T) {
 		SrcPort:          400,
 	}
 
+	log.Infof("Adding rule: %+v", udpRule)
+
 	// Add the policy
-	err = policyAgent.AddRule(udpRule, &resp)
+	err = ofnetMaster.AddRule(udpRule)
 	if err != nil {
 		t.Errorf("Error installing udpRule {%+v}. Err: %v", udpRule, err)
 	}
 
-	// Cleanup
-	ofnetAgent.Delete()
-	ovsDriver.DeleteBridge(brName)
+	// Get all the flows
+	flowList, err := ofctlFlowDump(brName)
+	if err != nil {
+		t.Errorf("Error getting flow entries. Err: %v", err)
+	}
+
+	// verify src group flow
+	srcGrpFlowMatch := fmt.Sprintf("priority=100,in_port=12 actions=push_vlan:0x8100,set_field:4097->vlan_vid,write_metadata:0x640000/0x7fff0000")
+	if !ofctlFlowMatch(flowList, VLAN_TBL_ID, srcGrpFlowMatch) {
+		t.Errorf("Could not find the route %s on ovs %s", srcGrpFlowMatch, brName)
+	}
+
+	log.Infof("Found src group %s on ovs %s", srcGrpFlowMatch, brName)
+
+	// verify dst group flow
+	dstGrpFlowMatch := fmt.Sprintf("priority=100,ip,nw_dst=10.2.2.2 actions=write_metadata:0xc8/0xfffe")
+	if !ofctlFlowMatch(flowList, DST_GRP_TBL_ID, dstGrpFlowMatch) {
+		t.Errorf("Could not find the route %s on ovs %s", dstGrpFlowMatch, brName)
+	}
+
+	log.Infof("Found dst group %s on ovs %s", dstGrpFlowMatch, brName)
+
+	// verify tcp rule flow entry exists
+	tcpFlowMatch := fmt.Sprintf("priority=100,tcp,metadata=0x640190/0x7ffffffe,nw_src=10.10.10.0/24,nw_dst=10.1.1.0/24,tp_src=200,tp_dst=100")
+	if !ofctlFlowMatch(flowList, POLICY_TBL_ID, tcpFlowMatch) {
+		t.Errorf("Could not find the route %s on ovs %s", tcpFlowMatch, brName)
+	}
+
+	log.Infof("Found tcp rule %s on ovs %s", tcpFlowMatch, brName)
+
+	// verify udp rule flow
+	udpFlowMatch := fmt.Sprintf("priority=100,udp,metadata=0x12c0320/0x7ffffffe,nw_src=20.20.20.0/24,nw_dst=20.2.2.0/24,tp_src=400,tp_dst=300")
+	if !ofctlFlowMatch(flowList, POLICY_TBL_ID, udpFlowMatch) {
+		t.Errorf("Could not find the route %s on ovs %s", udpFlowMatch, brName)
+	}
+
+	log.Infof("Found udp rule %s on ovs %s", udpFlowMatch, brName)
+
+	// Delete policies
+	err = ofnetMaster.DelRule(tcpRule)
+	if err != nil {
+		t.Errorf("Error deleting tcpRule {%+v}. Err: %v", tcpRule, err)
+	}
+	err = ofnetMaster.DelRule(udpRule)
+	if err != nil {
+		t.Errorf("Error deleting udpRule {%+v}. Err: %v", udpRule, err)
+	}
+	err = ofnetAgent.RemoveLocalEndpoint(endpoint.PortNo)
+	if err != nil {
+		t.Errorf("Error deleting endpoint: %+v. Err: %v", endpoint, err)
+	}
+
+	log.Infof("Deleted all policy entries")
+
+	// Get the flows again
+	flowList, err = ofctlFlowDump(brName)
+	if err != nil {
+		t.Errorf("Error getting flow entries. Err: %v", err)
+	}
+
+	// Make sure flows are gone
+	if ofctlFlowMatch(flowList, VLAN_TBL_ID, srcGrpFlowMatch) {
+		t.Errorf("Still found the flow %s on ovs %s", srcGrpFlowMatch, brName)
+	}
+	if ofctlFlowMatch(flowList, DST_GRP_TBL_ID, dstGrpFlowMatch) {
+		t.Errorf("Still found the flow %s on ovs %s", dstGrpFlowMatch, brName)
+	}
+	if ofctlFlowMatch(flowList, POLICY_TBL_ID, tcpFlowMatch) {
+		t.Errorf("Still found the flow %s on ovs %s", tcpFlowMatch, brName)
+	}
+	if ofctlFlowMatch(flowList, POLICY_TBL_ID, udpFlowMatch) {
+		t.Errorf("Still found the flow %s on ovs %s", udpFlowMatch, brName)
+	}
+
+	log.Infof("Verified all flows are deleted")
 }

--- a/ofnetPolicy_test.go
+++ b/ofnetPolicy_test.go
@@ -90,6 +90,7 @@ func TestPolicyAddDelete(t *testing.T) {
 
 	tcpRule := &OfnetPolicyRule{
 		RuleId:           "tcpRule",
+		Priority:         100,
 		SrcEndpointGroup: 100,
 		DstEndpointGroup: 200,
 		SrcIpAddr:        "10.10.10.10/24",
@@ -111,6 +112,7 @@ func TestPolicyAddDelete(t *testing.T) {
 
 	udpRule := &OfnetPolicyRule{
 		RuleId:           "udpRule",
+		Priority:         100,
 		SrcEndpointGroup: 300,
 		DstEndpointGroup: 400,
 		SrcIpAddr:        "20.20.20.20/24",
@@ -140,7 +142,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	// verify src group flow
 	srcGrpFlowMatch := fmt.Sprintf("priority=100,in_port=12 actions=write_metadata:0x640000/0x7fff0000")
 	if !ofctlFlowMatch(flowList, VLAN_TBL_ID, srcGrpFlowMatch) {
-		t.Errorf("Could not find the route %s on ovs %s", srcGrpFlowMatch, brName)
+		t.Errorf("Could not find the flow %s on ovs %s", srcGrpFlowMatch, brName)
 		return
 	}
 
@@ -149,25 +151,25 @@ func TestPolicyAddDelete(t *testing.T) {
 	// verify dst group flow
 	dstGrpFlowMatch := fmt.Sprintf("priority=100,ip,nw_dst=10.2.2.2 actions=write_metadata:0xc8/0xfffe")
 	if !ofctlFlowMatch(flowList, DST_GRP_TBL_ID, dstGrpFlowMatch) {
-		t.Errorf("Could not find the route %s on ovs %s", dstGrpFlowMatch, brName)
+		t.Errorf("Could not find the flow %s on ovs %s", dstGrpFlowMatch, brName)
 		return
 	}
 
 	log.Infof("Found dst group %s on ovs %s", dstGrpFlowMatch, brName)
 
 	// verify tcp rule flow entry exists
-	tcpFlowMatch := fmt.Sprintf("priority=100,tcp,metadata=0x640190/0x7ffffffe,nw_src=10.10.10.0/24,nw_dst=10.1.1.0/24,tp_src=200,tp_dst=100")
+	tcpFlowMatch := fmt.Sprintf("priority=110,tcp,metadata=0x640190/0x7ffffffe,nw_src=10.10.10.0/24,nw_dst=10.1.1.0/24,tp_src=200,tp_dst=100")
 	if !ofctlFlowMatch(flowList, POLICY_TBL_ID, tcpFlowMatch) {
-		t.Errorf("Could not find the route %s on ovs %s", tcpFlowMatch, brName)
+		t.Errorf("Could not find the flow %s on ovs %s", tcpFlowMatch, brName)
 		return
 	}
 
 	log.Infof("Found tcp rule %s on ovs %s", tcpFlowMatch, brName)
 
 	// verify udp rule flow
-	udpFlowMatch := fmt.Sprintf("priority=100,udp,metadata=0x12c0320/0x7ffffffe,nw_src=20.20.20.0/24,nw_dst=20.2.2.0/24,tp_src=400,tp_dst=300")
+	udpFlowMatch := fmt.Sprintf("priority=110,udp,metadata=0x12c0320/0x7ffffffe,nw_src=20.20.20.0/24,nw_dst=20.2.2.0/24,tp_src=400,tp_dst=300")
 	if !ofctlFlowMatch(flowList, POLICY_TBL_ID, udpFlowMatch) {
-		t.Errorf("Could not find the route %s on ovs %s", udpFlowMatch, brName)
+		t.Errorf("Could not find the flow %s on ovs %s", udpFlowMatch, brName)
 		return
 	}
 

--- a/ofnetPolicy_test.go
+++ b/ofnetPolicy_test.go
@@ -64,8 +64,6 @@ func TestPolicyAddDelete(t *testing.T) {
 		t.Fatalf("Error adding controller to ovs: %s", brName)
 	}
 
-	defer func() { ovsDriver.DeleteBridge(brName) }()
-
 	// Wait for switch to connect to controller
 	ofnetAgent.WaitForSwitchConnection()
 
@@ -87,6 +85,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	err = ofnetAgent.AddLocalEndpoint(endpoint)
 	if err != nil {
 		t.Errorf("Error adding endpoint. Err: %v", err)
+		return
 	}
 
 	tcpRule := &OfnetPolicyRule{
@@ -98,6 +97,7 @@ func TestPolicyAddDelete(t *testing.T) {
 		IpProtocol:       6,
 		DstPort:          100,
 		SrcPort:          200,
+		Action:           "accept",
 	}
 
 	log.Infof("Adding rule: %+v", tcpRule)
@@ -106,6 +106,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	err = ofnetMaster.AddRule(tcpRule)
 	if err != nil {
 		t.Errorf("Error installing tcpRule {%+v}. Err: %v", tcpRule, err)
+		return
 	}
 
 	udpRule := &OfnetPolicyRule{
@@ -117,6 +118,7 @@ func TestPolicyAddDelete(t *testing.T) {
 		IpProtocol:       17,
 		DstPort:          300,
 		SrcPort:          400,
+		Action:           "deny",
 	}
 
 	log.Infof("Adding rule: %+v", udpRule)
@@ -125,18 +127,21 @@ func TestPolicyAddDelete(t *testing.T) {
 	err = ofnetMaster.AddRule(udpRule)
 	if err != nil {
 		t.Errorf("Error installing udpRule {%+v}. Err: %v", udpRule, err)
+		return
 	}
 
 	// Get all the flows
 	flowList, err := ofctlFlowDump(brName)
 	if err != nil {
 		t.Errorf("Error getting flow entries. Err: %v", err)
+		return
 	}
 
 	// verify src group flow
-	srcGrpFlowMatch := fmt.Sprintf("priority=100,in_port=12 actions=push_vlan:0x8100,set_field:4097->vlan_vid,write_metadata:0x640000/0x7fff0000")
+	srcGrpFlowMatch := fmt.Sprintf("priority=100,in_port=12 actions=write_metadata:0x640000/0x7fff0000")
 	if !ofctlFlowMatch(flowList, VLAN_TBL_ID, srcGrpFlowMatch) {
 		t.Errorf("Could not find the route %s on ovs %s", srcGrpFlowMatch, brName)
+		return
 	}
 
 	log.Infof("Found src group %s on ovs %s", srcGrpFlowMatch, brName)
@@ -145,6 +150,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	dstGrpFlowMatch := fmt.Sprintf("priority=100,ip,nw_dst=10.2.2.2 actions=write_metadata:0xc8/0xfffe")
 	if !ofctlFlowMatch(flowList, DST_GRP_TBL_ID, dstGrpFlowMatch) {
 		t.Errorf("Could not find the route %s on ovs %s", dstGrpFlowMatch, brName)
+		return
 	}
 
 	log.Infof("Found dst group %s on ovs %s", dstGrpFlowMatch, brName)
@@ -153,6 +159,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	tcpFlowMatch := fmt.Sprintf("priority=100,tcp,metadata=0x640190/0x7ffffffe,nw_src=10.10.10.0/24,nw_dst=10.1.1.0/24,tp_src=200,tp_dst=100")
 	if !ofctlFlowMatch(flowList, POLICY_TBL_ID, tcpFlowMatch) {
 		t.Errorf("Could not find the route %s on ovs %s", tcpFlowMatch, brName)
+		return
 	}
 
 	log.Infof("Found tcp rule %s on ovs %s", tcpFlowMatch, brName)
@@ -161,6 +168,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	udpFlowMatch := fmt.Sprintf("priority=100,udp,metadata=0x12c0320/0x7ffffffe,nw_src=20.20.20.0/24,nw_dst=20.2.2.0/24,tp_src=400,tp_dst=300")
 	if !ofctlFlowMatch(flowList, POLICY_TBL_ID, udpFlowMatch) {
 		t.Errorf("Could not find the route %s on ovs %s", udpFlowMatch, brName)
+		return
 	}
 
 	log.Infof("Found udp rule %s on ovs %s", udpFlowMatch, brName)
@@ -169,14 +177,17 @@ func TestPolicyAddDelete(t *testing.T) {
 	err = ofnetMaster.DelRule(tcpRule)
 	if err != nil {
 		t.Errorf("Error deleting tcpRule {%+v}. Err: %v", tcpRule, err)
+		return
 	}
 	err = ofnetMaster.DelRule(udpRule)
 	if err != nil {
 		t.Errorf("Error deleting udpRule {%+v}. Err: %v", udpRule, err)
+		return
 	}
 	err = ofnetAgent.RemoveLocalEndpoint(endpoint.PortNo)
 	if err != nil {
 		t.Errorf("Error deleting endpoint: %+v. Err: %v", endpoint, err)
+		return
 	}
 
 	log.Infof("Deleted all policy entries")
@@ -185,21 +196,29 @@ func TestPolicyAddDelete(t *testing.T) {
 	flowList, err = ofctlFlowDump(brName)
 	if err != nil {
 		t.Errorf("Error getting flow entries. Err: %v", err)
+		return
 	}
 
 	// Make sure flows are gone
 	if ofctlFlowMatch(flowList, VLAN_TBL_ID, srcGrpFlowMatch) {
 		t.Errorf("Still found the flow %s on ovs %s", srcGrpFlowMatch, brName)
+		return
 	}
 	if ofctlFlowMatch(flowList, DST_GRP_TBL_ID, dstGrpFlowMatch) {
 		t.Errorf("Still found the flow %s on ovs %s", dstGrpFlowMatch, brName)
+		return
 	}
 	if ofctlFlowMatch(flowList, POLICY_TBL_ID, tcpFlowMatch) {
 		t.Errorf("Still found the flow %s on ovs %s", tcpFlowMatch, brName)
+		return
 	}
 	if ofctlFlowMatch(flowList, POLICY_TBL_ID, udpFlowMatch) {
 		t.Errorf("Still found the flow %s on ovs %s", udpFlowMatch, brName)
+		return
 	}
 
 	log.Infof("Verified all flows are deleted")
+
+	// Delete the bridge
+	ovsDriver.DeleteBridge(brName)
 }

--- a/ofnet_test.go
+++ b/ofnet_test.go
@@ -160,8 +160,10 @@ func TestOfnetInit(t *testing.T) {
 // test adding vlan
 func TestOfnetSetupVlan(t *testing.T) {
 	for i := 0; i < NUM_AGENT; i++ {
-		for j := 1; j < 10; j++ {
-			log.Infof("Adding Vlan %d on %s", j, localIpList[i])
+		log.Info("Infex %d \n", i)
+		for j := 1; j < 5; j++ {
+			log.Info("Infex %d \n", j)
+			//log.Infof("Adding Vlan %d on %s", j, localIpList[i])
 			err := vrtrAgents[i].AddVlan(uint16(j), uint32(j))
 			if err != nil {
 				t.Errorf("Error adding vlan %d. Err: %v", j, err)

--- a/ofnet_test.go
+++ b/ofnet_test.go
@@ -586,7 +586,6 @@ func TestOfnetVlrouteAddDelete(t *testing.T) {
 		t.Errorf("Error getting flow entries. Err: %v", err)
 		return
 	}
-	log.Infof("FLOWLIST ISSSSS %v", flowList)
 
 	// verify flow entry exists
 	ipFlowMatch := fmt.Sprintf("priority=100,ip,nw_dst=20.20.20.20")

--- a/vlanBridge.go
+++ b/vlanBridge.go
@@ -121,3 +121,13 @@ func (self *VlanBridge) RemoveEndpoint(endpoint *OfnetEndpoint) error {
 
 	return nil
 }
+
+// AddUplink adds an uplink to the switch
+func (self *VlanBridge) AddUplink(portNo uint32) error {
+	return nil
+}
+
+// RemoveUplink remove an uplink to the switch
+func (self *VlanBridge) RemoveUplink(portNo uint32) error {
+	return nil
+}

--- a/vlrouter.go
+++ b/vlrouter.go
@@ -596,7 +596,7 @@ func (self *Vlrouter) processArp(pkt protocol.Ethernet, inPort uint32) {
 					endpoint.MacAddrStr = arpHdr.HWSrc.String()
 					self.agent.endpointDb[endpoint.EndpointID] = endpoint
 					self.AddEndpoint(endpoint)
-					self.ResolveUnresolvedRoutes(endpoint.MacAddrStr, inPort)
+					self.ResolveUnresolvedEPs(endpoint.MacAddrStr, inPort)
 
 				}
 			}
@@ -642,7 +642,10 @@ func (self *Vlrouter) RemoveVtepPort(portNo uint32, remoteIp net.IP) error {
 	return nil
 }
 
-func (self *Vlrouter) ResolveUnresolvedRoutes(MacAddrStr string, portNo uint32) {
+/*ResolveUnresolvedEPs walks through the unresolved endpoint list and resolves
+over given mac and port*/
+
+func (self *Vlrouter) ResolveUnresolvedEPs(MacAddrStr string, portNo uint32) {
 
 	for self.unresolvedEPs.Len() > 0 {
 		Element := self.unresolvedEPs.Front()

--- a/vlrouter.go
+++ b/vlrouter.go
@@ -58,6 +58,7 @@ type Vlrouter struct {
 	myRouterMac   net.HardwareAddr //Router mac used for external proxy
 	MyBgpPeer     string           // bgp neighbor
 	unresolvedEPs *list.List       // unresolved endpoint list
+
 }
 
 // Create a new vlrouter instance
@@ -464,7 +465,7 @@ func (self *Vlrouter) processArp(pkt protocol.Ethernet, inPort uint32) {
 			if endpoint != nil && endpoint.EndpointType == "external-bgp" {
 				//endpoint exists from where the arp is received.
 				if endpoint.PortNo == 0 {
-					log.Infof("Received ARP from BGP Peer over : Resolving over", endpoint.PortNo, endpoint.MacAddrStr)
+					log.Infof("Received ARP from BGP Peer on %s: Mac: %s", endpoint.PortNo, endpoint.MacAddrStr)
 					//learn the mac address and portno for the endpoint
 					self.RemoveEndpoint(endpoint)
 					endpoint.PortNo = inPort

--- a/vlrouter.go
+++ b/vlrouter.go
@@ -202,7 +202,7 @@ func (self *Vlrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 		localEpIP:    endpoint.IpAddr.String(),
 		nextHopIP:    self.agent.GetRouterInfo().RouterIP,
 	}
-
+	log.Infof("ADDING LOCAL ROUTE AND PASSING TO BGP")
 	self.agent.AddLocalProtoRoute(path)
 
 	return nil

--- a/vlrouter.go
+++ b/vlrouter.go
@@ -257,8 +257,6 @@ func (self *Vlrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 	if res.Code != api.Error_SUCCESS {
 		return fmt.Errorf("error: code: %d, msg: %s", res.Code, res.Msg)
 	}
-	log.Infof("PRINTING THE RIB")
-	self.agent.ShowRib()
 
 	return nil
 }

--- a/vlrouter.go
+++ b/vlrouter.go
@@ -222,7 +222,7 @@ func (self *Vlrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65002})}
 	aspath, _ := bgp.NewPathAttributeAsPath(aspathParam).Serialize()
 	path.Pattrs = append(path.Pattrs, aspath)
-	n, _ := bgp.NewPathAttributeNextHop(self.agent.routerIP).Serialize()
+	n, _ := bgp.NewPathAttributeNextHop(self.agent.GetRouterInfo().RouterIP).Serialize()
 	path.Pattrs = append(path.Pattrs, n)
 
 	name := ""
@@ -311,7 +311,7 @@ func (self *Vlrouter) RemoveLocalEndpoint(endpoint OfnetEndpoint) error {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65002})}
 	aspath, _ := bgp.NewPathAttributeAsPath(aspathParam).Serialize()
 	path.Pattrs = append(path.Pattrs, aspath)
-	n, _ := bgp.NewPathAttributeNextHop(self.agent.routerIP).Serialize()
+	n, _ := bgp.NewPathAttributeNextHop(self.agent.GetRouterInfo().RouterIP).Serialize()
 	path.Pattrs = append(path.Pattrs, n)
 	path.IsWithdraw = true
 	name := ""
@@ -566,7 +566,7 @@ func (self *Vlrouter) processArp(pkt protocol.Ethernet, inPort uint32) {
 			} else {
 				if endpoint.EndpointType == "internal" || endpoint.EndpointType == "internal-bgp" {
 					//srcMac, _ = net.ParseMAC(endpoint.MacAddrStr)
-					intf, _ = net.InterfaceByName(self.agent.vlanIntf)
+					intf, _ = net.InterfaceByName(self.agent.GetRouterInfo().VlanIntf)
 					srcMac = intf.HardwareAddr
 				} else if endpoint.EndpointType == "external" || endpoint.EndpointType == "external-bgp" {
 					endpoint = self.agent.getEndpointByIp(arpHdr.IPSrc)

--- a/vrouter.go
+++ b/vrouter.go
@@ -143,7 +143,8 @@ func (self *Vrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 	}
 
 	// Set the vlan and install it
-	portVlanFlow.SetVlan(endpoint.Vlan)
+	// FIXME: Dont set the vlan till multi-vrf support. We cant pop vlan unless flow matches on vlan
+	// portVlanFlow.SetVlan(endpoint.Vlan)
 
 	// Set source endpoint group if specified
 	if endpoint.EndpointGroup != 0 {
@@ -258,7 +259,7 @@ func (self *Vrouter) AddVtepPort(portNo uint32, remoteIp net.IP) error {
 	}
 
 	// FIXME: Need to match on tunnelId and set vlan-id per VRF
-	// FIXME: not needed till multi-vrf support
+	// FIXME: not needed till multi-vrf support. We cant pop vlan unless flow matches on vlan
 	// portVlanFlow.SetVlan(1)
 
 	portVlanFlow.Next(self.ipTable)
@@ -327,6 +328,7 @@ func (self *Vrouter) AddEndpoint(endpoint *OfnetEndpoint) error {
 	// Set VNI
 	// FIXME: hardcode VNI for default VRF.
 	// FIXME: We need to use fabric VNI per VRF
+	// FIXME: Cant pop vlan tag till the flow matches on vlan.
 	ipFlow.SetTunnelId(1)
 
 	// Point it to output port

--- a/vrouter.go
+++ b/vrouter.go
@@ -1,11 +1,9 @@
 /***
 Copyright 2014 Cisco Systems Inc. All rights reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,7 +55,6 @@ type Vrouter struct {
 	// Flow Database
 	flowDb         map[string]*ofctrl.Flow // Database of flow entries
 	portVlanFlowDb map[uint32]*ofctrl.Flow // Database of flow entries
-	vlanDb         map[uint16]*Vlan        // Database of known vlans
 
 	// Router Mac to be used
 	myRouterMac net.HardwareAddr
@@ -143,15 +140,9 @@ func (self *Vrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 		return err
 	}
 
-	vni := self.agent.vlanVniMap[endpoint.Vlan]
-	if vni == nil {
-		log.Errorf("VNI for vlan %d is not known", endpoint.Vlan)
-		return errors.New("Unknown Vlan")
-	}
-
 	// Set the vlan and install it
 	// FIXME: Dont set the vlan till multi-vrf support. We cant pop vlan unless flow matches on vlan
-	portVlanFlow.SetVlan(endpoint.Vlan)
+	// portVlanFlow.SetVlan(endpoint.Vlan)
 
 	// Set source endpoint group if specified
 	if endpoint.EndpointGroup != 0 {
@@ -182,7 +173,6 @@ func (self *Vrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 		Priority:  FLOW_MATCH_PRIORITY,
 		Ethertype: 0x0800,
 		IpDa:      &endpoint.IpAddr,
-		VlanId:    endpoint.Vlan,
 	})
 	if err != nil {
 		log.Errorf("Error creating flow for endpoint: %+v. Err: %v", endpoint, err)
@@ -194,7 +184,6 @@ func (self *Vrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 	// Set Mac addresses
 	ipFlow.SetMacDa(destMacAddr)
 	ipFlow.SetMacSa(self.myRouterMac)
-	ipFlow.PopVlan()
 
 	// Point the route at output port
 	err = ipFlow.Next(outPort)
@@ -251,131 +240,51 @@ func (self *Vrouter) RemoveLocalEndpoint(endpoint OfnetEndpoint) error {
 	return nil
 }
 
+// Add virtual tunnel end point. This is mainly used for mapping remote vtep IP
+// to ofp port number.
 func (self *Vrouter) AddVtepPort(portNo uint32, remoteIp net.IP) error {
-	// Install VNI to vlan mapping for each vni
-	for vni, vlan := range self.agent.vniVlanMap {
-		// Install a flow entry for  VNI/vlan and point it to Ip table
-		portVlanFlow, err := self.vlanTable.NewFlow(ofctrl.FlowMatch{
-			Priority:  FLOW_MATCH_PRIORITY,
-			InputPort: portNo,
-			TunnelId:  uint64(vni),
-		})
-		if err != nil && strings.Contains(err.Error(), "Flow already exists") {
-			log.Infof("VTEP %s already exists", remoteIp.String())
-			return nil
-		} else if err != nil {
-			log.Errorf("Error adding Flow for VTEP %v. Err: %v", remoteIp, err)
-			return err
-		}
-
-		portVlanFlow.SetVlan(*vlan)
-
-		// Set the metadata to indicate packet came in from VTEP port
-		portVlanFlow.SetMetadata(METADATA_RX_VTEP, METADATA_RX_VTEP)
-
-		// Point to next table
-		// Note that we bypass policy lookup on dest host.
-		portVlanFlow.Next(self.ipTable)
+	// Install a flow entry for default VNI/vlan and point it to IP table
+	portVlanFlow, err := self.vlanTable.NewFlow(ofctrl.FlowMatch{
+		Priority:  FLOW_MATCH_PRIORITY,
+		InputPort: portNo,
+	})
+	if err != nil && strings.Contains(err.Error(), "Flow already exists") {
+		log.Infof("VTEP %s already exists", remoteIp.String())
+		return nil
+	} else if err != nil {
+		log.Errorf("Error adding Flow for VTEP %v. Err: %v", remoteIp, err)
+		return err
 	}
 
-	// Walk all vlans and add vtep port to the vlan
-	for vlanId, vlan := range self.vlanDb {
-		vni := self.agent.vlanVniMap[vlanId]
-		if vni == nil {
-			log.Errorf("Can not find vni for vlan: %d", vlanId)
-		}
-		output, _ := self.ofSwitch.OutputPort(portNo)
-		vlan.allFlood.AddTunnelOutput(output, uint64(*vni))
-	}
+	// FIXME: Need to match on tunnelId and set vlan-id per VRF
+	// FIXME: not needed till multi-vrf support. We cant pop vlan unless flow matches on vlan
+	// portVlanFlow.SetVlan(1)
+
+	// Point it to next table.
+	// Note that we bypass policy lookup on dest host.
+	portVlanFlow.Next(self.ipTable)
+
+	// FIXME: walk all the routes and see if we can install it
+	//        This could happen if a route made it to us before VTEP
+
 	return nil
 }
 
 // Remove a VTEP port
 func (self *Vrouter) RemoveVtepPort(portNo uint32, remoteIp net.IP) error {
-	// Remove the VTEP from flood lists
-	output, _ := self.ofSwitch.OutputPort(portNo)
-	for _, vlan := range self.vlanDb {
-		// Walk all vlans and remove from flood lists
-		vlan.allFlood.RemoveOutput(output)
-	}
-
-	// FIXME: uninstall vlan-vni mapping.
 	return nil
 }
 
 // Add a vlan.
 // This is mainly used for mapping vlan id to Vxlan VNI
 func (self *Vrouter) AddVlan(vlanId uint16, vni uint32) error {
-	// check if the vlan already exists. if it does, we are done
-	if self.vlanDb[vlanId] != nil {
-		return nil
-	}
-
-	// create new vlan object
-	vlan := new(Vlan)
-	vlan.Vni = vni
-	vlan.localPortList = make(map[uint32]*uint32)
-	vlan.allPortList = make(map[uint32]*uint32)
-
-	// Create flood entries
-	vlan.localFlood, _ = self.ofSwitch.NewFlood()
-	vlan.allFlood, _ = self.ofSwitch.NewFlood()
-
-	// Walk all VTEP ports and add vni-vlan mapping for new VNI
-	for _, vtepPort := range self.agent.vtepTable {
-		// Install a flow entry for  VNI/vlan and point it to macDest table
-		portVlanFlow, err := self.vlanTable.NewFlow(ofctrl.FlowMatch{
-			Priority:  FLOW_MATCH_PRIORITY,
-			InputPort: *vtepPort,
-			TunnelId:  uint64(vni),
-		})
-		if err != nil {
-			log.Errorf("Error creating port vlan flow for vlan %d. Err: %v", vlanId, err)
-			return err
-		}
-
-		// Set vlan id
-		portVlanFlow.SetVlan(vlanId)
-
-		// Set the metadata to indicate packet came in from VTEP port
-		portVlanFlow.SetMetadata(METADATA_RX_VTEP, METADATA_RX_VTEP)
-
-		// Point to next table
-		dstGrpTbl := self.ofSwitch.GetTable(DST_GRP_TBL_ID)
-		portVlanFlow.Next(dstGrpTbl)
-	}
-
-	// Walk all VTEP ports and add it to the allFlood list
-	for _, vtepPort := range self.agent.vtepTable {
-		output, _ := self.ofSwitch.OutputPort(*vtepPort)
-		vlan.allFlood.AddTunnelOutput(output, uint64(vni))
-	}
-
-	// store it in DB
-	self.vlanDb[vlanId] = vlan
-
+	// FIXME: Add this for multiple VRF support
 	return nil
 }
 
 // Remove a vlan
 func (self *Vrouter) RemoveVlan(vlanId uint16, vni uint32) error {
-	vlan := self.vlanDb[vlanId]
-	if vlan == nil {
-		log.Fatalf("Could not find the vlan %d", vlanId)
-	}
-
-	// Make sure the flood lists are empty
-	if (vlan.allFlood.NumOutput() != 0) || (vlan.localFlood.NumOutput() != 0) {
-		log.Fatalf("VLAN flood list is not empty")
-	}
-
-	// Uninstall the flood lists
-	vlan.allFlood.Delete()
-	vlan.localFlood.Delete()
-
-	// Remove it from DB
-	delete(self.vlanDb, vlanId)
-
+	// FIXME: Add this for multiple VRF support
 	return nil
 }
 
@@ -391,13 +300,6 @@ func (self *Vrouter) AddEndpoint(endpoint *OfnetEndpoint) error {
 		return errors.New("VTEP not found")
 	}
 
-	// map VNI to vlan Id
-	VrfVniId := self.agent.vlanVniMap[endpoint.VrfId]
-	if VrfVniId == nil {
-		log.Errorf("Endpoint %+v on unknown VNI: %d", endpoint, endpoint.Vni)
-		return errors.New("Unknown VNI")
-	}
-
 	// Install the endpoint in OVS
 	// Create an output port for the vtep
 	outPort, err := self.ofSwitch.OutputPort(*vtepPort)
@@ -411,7 +313,6 @@ func (self *Vrouter) AddEndpoint(endpoint *OfnetEndpoint) error {
 		Priority:  FLOW_MATCH_PRIORITY,
 		Ethertype: 0x0800,
 		IpDa:      &endpoint.IpAddr,
-		VlanId:    endpoint.VrfId,
 	})
 	if err != nil {
 		log.Errorf("Error creating flow for endpoint: %+v. Err: %v", endpoint, err)
@@ -428,10 +329,7 @@ func (self *Vrouter) AddEndpoint(endpoint *OfnetEndpoint) error {
 	// FIXME: hardcode VNI for default VRF.
 	// FIXME: We need to use fabric VNI per VRF
 	// FIXME: Cant pop vlan tag till the flow matches on vlan.
-	//	ipFlow.SetTunnelId(1)
-	ipFlow.PopVlan()
-	ipFlow.SetTunnelId(uint64(endpoint.Vni))
-	ipFlow.Next(outPort)
+	ipFlow.SetTunnelId(1)
 
 	// Point it to output port
 	err = ipFlow.Next(outPort)

--- a/vrouter.go
+++ b/vrouter.go
@@ -376,6 +376,18 @@ func (self *Vrouter) RemoveEndpoint(endpoint *OfnetEndpoint) error {
 	return nil
 }
 
+// AddUplink adds an uplink to the switch
+func (vr *Vrouter) AddUplink(portNo uint32) error {
+	// Nothing to do
+	return nil
+}
+
+// RemoveUplink remove an uplink to the switch
+func (vr *Vrouter) RemoveUplink(portNo uint32) error {
+	// Nothing to do
+	return nil
+}
+
 // initialize Fgraph on the switch
 func (self *Vrouter) initFgraph() error {
 	sw := self.ofSwitch

--- a/vrouter.go
+++ b/vrouter.go
@@ -262,6 +262,8 @@ func (self *Vrouter) AddVtepPort(portNo uint32, remoteIp net.IP) error {
 	// FIXME: not needed till multi-vrf support. We cant pop vlan unless flow matches on vlan
 	// portVlanFlow.SetVlan(1)
 
+	// Point it to next table.
+	// Note that we bypass policy lookup on dest host.
 	portVlanFlow.Next(self.ipTable)
 
 	// FIXME: walk all the routes and see if we can install it

--- a/vrouter.go
+++ b/vrouter.go
@@ -44,8 +44,9 @@ import (
 // Vrouter state.
 // One Vrouter instance exists on each host
 type Vrouter struct {
-	agent    *OfnetAgent      // Pointer back to ofnet agent that owns this
-	ofSwitch *ofctrl.OFSwitch // openflow switch we are talking to
+	agent       *OfnetAgent      // Pointer back to ofnet agent that owns this
+	ofSwitch    *ofctrl.OFSwitch // openflow switch we are talking to
+	policyAgent *PolicyAgent     // Policy agent
 
 	// Fgraph tables
 	inputTable *ofctrl.Table // Packet lookup starts here
@@ -67,6 +68,9 @@ func NewVrouter(agent *OfnetAgent, rpcServ *rpc.Server) *Vrouter {
 	// Keep a reference to the agent
 	vrouter.agent = agent
 
+	// Create policy agent
+	vrouter.policyAgent = NewPolicyAgent(agent, rpcServ)
+
 	// Create a flow dbs and my router mac
 	vrouter.flowDb = make(map[string]*ofctrl.Flow)
 	vrouter.portVlanFlowDb = make(map[uint32]*ofctrl.Flow)
@@ -87,6 +91,9 @@ func (self *Vrouter) SwitchConnected(sw *ofctrl.OFSwitch) {
 	self.ofSwitch = sw
 
 	log.Infof("Switch connected(vrouter). installing flows")
+
+	// Tell the policy agent about the switch
+	self.policyAgent.SwitchConnected(sw)
 
 	// Init the Fgraph
 	self.initFgraph()
@@ -136,7 +143,16 @@ func (self *Vrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 
 	// Set the vlan and install it
 	portVlanFlow.SetVlan(endpoint.Vlan)
-	err = portVlanFlow.Next(self.ipTable)
+
+	// Set source endpoint group if specified
+	if endpoint.EndpointGroup != 0 {
+		metadata, metadataMask := SrcGroupMetadata(endpoint.EndpointGroup)
+		portVlanFlow.SetMetadata(metadata, metadataMask)
+	}
+
+	// Point it to dst group table for policy lookups
+	dstGrpTbl := self.ofSwitch.GetTable(DST_GRP_TBL_ID)
+	err = portVlanFlow.Next(dstGrpTbl)
 	if err != nil {
 		log.Errorf("Error installing portvlan entry. Err: %v", err)
 		return err
@@ -176,6 +192,13 @@ func (self *Vrouter) AddLocalEndpoint(endpoint OfnetEndpoint) error {
 		return err
 	}
 
+	// Install dst group entry for the endpoint
+	err = self.policyAgent.AddEndpoint(&endpoint)
+	if err != nil {
+		log.Errorf("Error adding endpoint to policy agent{%+v}. Err: %v", endpoint, err)
+		return err
+	}
+
 	// Store the flow
 	self.flowDb[endpoint.IpAddr.String()] = ipFlow
 
@@ -205,6 +228,13 @@ func (self *Vrouter) RemoveLocalEndpoint(endpoint OfnetEndpoint) error {
 	err := ipFlow.Delete()
 	if err != nil {
 		log.Errorf("Error deleting the endpoint: %+v. Err: %v", endpoint, err)
+	}
+
+	// Remove the endpoint from policy tables
+	err = self.policyAgent.DelEndpoint(&endpoint)
+	if err != nil {
+		log.Errorf("Error deleting endpoint to policy agent{%+v}. Err: %v", endpoint, err)
+		return err
 	}
 
 	return nil
@@ -297,6 +327,13 @@ func (self *Vrouter) AddEndpoint(endpoint *OfnetEndpoint) error {
 		return err
 	}
 
+	// Install dst group entry for the endpoint
+	err = self.policyAgent.AddEndpoint(endpoint)
+	if err != nil {
+		log.Errorf("Error adding endpoint to policy agent{%+v}. Err: %v", endpoint, err)
+		return err
+	}
+
 	// Store it in flow db
 	self.flowDb[endpoint.IpAddr.String()] = ipFlow
 
@@ -318,11 +355,15 @@ func (self *Vrouter) RemoveEndpoint(endpoint *OfnetEndpoint) error {
 		log.Errorf("Error deleting the endpoint: %+v. Err: %v", endpoint, err)
 	}
 
+	// Remove the endpoint from policy tables
+	err = self.policyAgent.DelEndpoint(endpoint)
+	if err != nil {
+		log.Errorf("Error deleting endpoint to policy agent{%+v}. Err: %v", endpoint, err)
+		return err
+	}
+
 	return nil
 }
-
-const VLAN_TBL_ID = 1
-const IP_TBL_ID = 4
 
 // initialize Fgraph on the switch
 func (self *Vrouter) initFgraph() error {
@@ -332,6 +373,13 @@ func (self *Vrouter) initFgraph() error {
 	self.inputTable = sw.DefaultTable()
 	self.vlanTable, _ = sw.NewTable(VLAN_TBL_ID)
 	self.ipTable, _ = sw.NewTable(IP_TBL_ID)
+
+	// Init policy tables
+	err := self.policyAgent.InitTables(IP_TBL_ID)
+	if err != nil {
+		log.Fatalf("Error installing policy table. Err: %v", err)
+		return err
+	}
 
 	//Create all drop entries
 	// Drop mcast source mac

--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -435,8 +435,6 @@ func (self *Vxlan) RemoveEndpoint(endpoint *OfnetEndpoint) error {
 	return nil
 }
 
-const MAC_DEST_TBL_ID = 5
-
 // initialize Fgraph on the switch
 func (self *Vxlan) initFgraph() error {
 	sw := self.ofSwitch

--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -532,6 +532,16 @@ func (self *Vxlan) RemoveEndpoint(endpoint *OfnetEndpoint) error {
 	return nil
 }
 
+// AddUplink adds an uplink to the switch
+func (vx *Vxlan) AddUplink(portNo uint32) error {
+	return nil
+}
+
+// RemoveUplink remove an uplink to the switch
+func (vx *Vxlan) RemoveUplink(portNo uint32) error {
+	return nil
+}
+
 // initialize Fgraph on the switch
 func (self *Vxlan) initFgraph() error {
 	sw := self.ofSwitch


### PR DESCRIPTION

The commit contains changes to ofnet library required for L3 support for containers.

The Changes contain:
1) Creation of new datapath forwarding mode : VLrouter. VLrouter  mode supports routing at the host for   vlan network (currently on default network)
2) GoBgp intgreation to distribute container EPs to non container workload.
3) GoBgp support to learn routes towards non container workloads
5) Creation of internal ovs port and used as router interface to run BGP
4) Proxy ARP capability and ARP learning capability
5) Unit Tests

