### PR TITLE
Arp suppression changes in ofnet

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -74,19 +74,19 @@
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/common",
-			"Rev": "f5b2bac2a467b2ac02a12bdf2e235550271d7387"
+			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/openflow13",
-			"Rev": "f5b2bac2a467b2ac02a12bdf2e235550271d7387"
+			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/protocol",
-			"Rev": "f5b2bac2a467b2ac02a12bdf2e235550271d7387"
+			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/util",
-			"Rev": "f5b2bac2a467b2ac02a12bdf2e235550271d7387"
+			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
 		},
 		{
 			"ImportPath": "github.com/vishvananda/netlink",

--- a/Godeps/_workspace/src/github.com/shaleman/libOpenflow/openflow13/match.go
+++ b/Godeps/_workspace/src/github.com/shaleman/libOpenflow/openflow13/match.go
@@ -204,6 +204,7 @@ func DecodeMatchField(class uint16, field uint8, data []byte) util.Message {
 		case OXM_FIELD_ICMPV4_TYPE:
 		case OXM_FIELD_ICMPV4_CODE:
 		case OXM_FIELD_ARP_OP:
+			val = new(ArpOperField)
 		case OXM_FIELD_ARP_SPA:
 		case OXM_FIELD_ARP_TPA:
 		case OXM_FIELD_ARP_SHA:
@@ -804,5 +805,36 @@ func NewTcpFlagsField(tcpFlag uint16, tcpFlagMask *uint16) *MatchField {
 	return f
 }
 
-// FIXME: Need to add following fields
-// ARP_OP
+// ARP Oper type field
+type ArpOperField struct {
+	ArpOper uint16
+}
+
+func (m *ArpOperField) Len() uint16 {
+	return 2
+}
+func (m *ArpOperField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 2)
+
+	binary.BigEndian.PutUint16(data, m.ArpOper)
+	return
+}
+func (m *ArpOperField) UnmarshalBinary(data []byte) error {
+	m.ArpOper = binary.BigEndian.Uint16(data)
+	return nil
+}
+
+// Return a MatchField for arp operation type matching
+func NewArpOperField(arpOper uint16) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_ARP_OP
+	f.HasMask = false
+
+	arpOperField := new(ArpOperField)
+	arpOperField.ArpOper = arpOper
+	f.Value = arpOperField
+	f.Length = uint8(arpOperField.Len())
+
+	return f
+}

--- a/Godeps/_workspace/src/github.com/shaleman/libOpenflow/protocol/arp.go
+++ b/Godeps/_workspace/src/github.com/shaleman/libOpenflow/protocol/arp.go
@@ -1,90 +1,91 @@
 package protocol
 
 import (
-    "encoding/binary"
-    "errors"
-    "net"
+	"encoding/binary"
+	"errors"
+	"net"
 )
 
 const (
-    Type_Request = 1
-    Type_Reply   = 2
+	Type_Request = 1
+	Type_Reply   = 2
 )
 
 type ARP struct {
-    HWType      uint16
-    ProtoType   uint16
-    HWLength    uint8
-    ProtoLength uint8
-    Operation   uint16
-    HWSrc       net.HardwareAddr
-    IPSrc       net.IP
-    HWDst       net.HardwareAddr
-    IPDst       net.IP
+	HWType      uint16
+	ProtoType   uint16
+	HWLength    uint8
+	ProtoLength uint8
+	Operation   uint16
+	HWSrc       net.HardwareAddr
+	IPSrc       net.IP
+	HWDst       net.HardwareAddr
+	IPDst       net.IP
 }
 
 func NewARP(opt int) (*ARP, error) {
-    if opt != Type_Request && opt != Type_Reply {
-        return nil, errors.New("Invalid ARP Operation.")
-    }
-    a := new(ARP)
-    a.HWType = 1
-    a.ProtoType = 0x800
-    a.HWLength = 6
-    a.ProtoLength = 4
-    a.Operation = uint16(opt)
-    a.HWSrc = net.HardwareAddr(make([]byte, 6))
-    a.IPSrc = net.IP(make([]byte, 4))
-    a.HWDst = net.HardwareAddr(make([]byte, 6))
-    a.IPDst = net.IP(make([]byte, 4))
-    return a, nil
+	if opt != Type_Request && opt != Type_Reply {
+		return nil, errors.New("Invalid ARP Operation.")
+	}
+	a := new(ARP)
+	a.HWType = 1
+	a.ProtoType = 0x800
+	a.HWLength = 6
+	a.ProtoLength = 4
+	a.Operation = uint16(opt)
+	a.HWSrc = net.HardwareAddr(make([]byte, 6))
+	a.IPSrc = net.IP(make([]byte, 4))
+	a.HWDst = net.HardwareAddr(make([]byte, 6))
+	a.IPDst = net.IP(make([]byte, 4))
+	return a, nil
 }
 
 func (a *ARP) Len() (n uint16) {
-    n = 8
-    n += uint16(a.HWLength * 2 + a.ProtoLength * 2)
-    return
+	n = 8
+	n += uint16(a.HWLength*2 + a.ProtoLength*2)
+	return
 }
 
 func (a *ARP) MarshalBinary() (data []byte, err error) {
-    data = make([]byte, int(a.Len()))
-    binary.BigEndian.PutUint16(data[:2], a.HWType)
-    binary.BigEndian.PutUint16(data[2:4], a.ProtoType)
-    data[4] = a.HWLength
-    data[5] = a.ProtoLength
-    binary.BigEndian.PutUint16(data[6:8], a.Operation)
+	data = make([]byte, int(a.Len()))
+	binary.BigEndian.PutUint16(data[:2], a.HWType)
+	binary.BigEndian.PutUint16(data[2:4], a.ProtoType)
+	data[4] = a.HWLength
+	data[5] = a.ProtoLength
+	binary.BigEndian.PutUint16(data[6:8], a.Operation)
 
-    n := 8
-    copy(data[n:n+int(a.HWLength)], a.HWSrc)
-    n += int(a.HWLength)
-    copy(data[n:n+int(a.ProtoLength)], a.IPSrc)
-    n += int(a.ProtoLength)
-    copy(data[n:n+int(a.HWLength)], a.HWDst)
-    n += int(a.HWLength)
-    copy(data[n:n+int(a.ProtoLength)], a.IPDst)
-    return data, nil
+	n := 8
+
+	copy(data[n:n+int(a.HWLength)], a.HWSrc)
+	n += int(a.HWLength)
+	copy(data[n:n+int(a.ProtoLength)], a.IPSrc.To4())
+	n += int(a.ProtoLength)
+	copy(data[n:n+int(a.HWLength)], a.HWDst)
+	n += int(a.HWLength)
+	copy(data[n:n+int(a.ProtoLength)], a.IPDst.To4())
+	return data, nil
 }
 
 func (a *ARP) UnmarshalBinary(data []byte) error {
-    if len(data) < 8 {
-        return errors.New("The []byte is too short to unmarshal a full ARP message.")
-    }
-    a.HWType = binary.BigEndian.Uint16(data[:2])
-    a.ProtoType = binary.BigEndian.Uint16(data[2:4])
-    a.HWLength = data[4]
-    a.ProtoLength = data[5]
-    a.Operation = binary.BigEndian.Uint16(data[6:8])
+	if len(data) < 8 {
+		return errors.New("The []byte is too short to unmarshal a full ARP message.")
+	}
+	a.HWType = binary.BigEndian.Uint16(data[:2])
+	a.ProtoType = binary.BigEndian.Uint16(data[2:4])
+	a.HWLength = data[4]
+	a.ProtoLength = data[5]
+	a.Operation = binary.BigEndian.Uint16(data[6:8])
 
-    n := 8
-    if len(data[n:]) < (int(a.HWLength) * 2 + int(a.ProtoLength) * 2) {
-        return errors.New("The []byte is too short to unmarshal a full ARP message.")
-    }
-    a.HWSrc = data[n:n+int(a.HWLength)]
-    n += int(a.HWLength)
-    a.IPSrc = data[n:n+int(a.ProtoLength)]
-    n += int(a.ProtoLength)
-    a.HWDst = data[n:n+int(a.HWLength)]
-    n += int(a.HWLength)
-    a.IPDst = data[n:n+int(a.ProtoLength)]
-    return nil
+	n := 8
+	if len(data[n:]) < (int(a.HWLength)*2 + int(a.ProtoLength)*2) {
+		return errors.New("The []byte is too short to unmarshal a full ARP message.")
+	}
+	a.HWSrc = data[n : n+int(a.HWLength)]
+	n += int(a.HWLength)
+	a.IPSrc = data[n : n+int(a.ProtoLength)]
+	n += int(a.ProtoLength)
+	a.HWDst = data[n : n+int(a.HWLength)]
+	n += int(a.HWLength)
+	a.IPDst = data[n : n+int(a.ProtoLength)]
+	return nil
 }

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -35,6 +35,7 @@ type FlowMatch struct {
 	MacSaMask    *net.HardwareAddr // Mac source mask
 	Ethertype    uint16            // Ethertype
 	VlanId       uint16            // vlan id
+	ArpOper      uint16            // ARP Oper type
 	IpSa         *net.IP
 	IpSaMask     *net.IP
 	IpDa         *net.IP
@@ -141,6 +142,12 @@ func (self *Flow) xlateMatch() openflow13.Match {
 	if self.Match.VlanId != 0 {
 		vidField := openflow13.NewVlanIdField(self.Match.VlanId)
 		ofMatch.AddField(*vidField)
+	}
+
+	// Handle ARP Oper type
+	if self.Match.ArpOper != 0 {
+		arpOperField := openflow13.NewArpOperField(self.Match.ArpOper)
+		ofMatch.AddField(*arpOperField)
 	}
 
 	// Handle IP Dst

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -49,7 +49,7 @@ func (o *OfActor) SwitchConnected(sw *OFSwitch) {
 }
 
 func (o *OfActor) SwitchDisconnected(sw *OFSwitch) {
-	log.Printf("App: Switch connected: %v", sw.DPID())
+	log.Printf("App: Switch disconnected: %v", sw.DPID())
 }
 
 var ofActor OfActor
@@ -173,7 +173,7 @@ func TestTableCreateDelete(t *testing.T) {
 	log.Infof("Deleting tables..")
 
 	// delete the tables
-	for i := 2; i < 10; i++ {
+	for i := 2; i < 12; i++ {
 		err := tables[i].Delete()
 		if err != nil {
 			t.Errorf("Error deleting table: %d", i)


### PR DESCRIPTION
This change sends out Proxy ARP response in L2 mode which reduces the number of ARP packets being flooded.

ARP request handling in various scenarios:
- Src and Dest EP known:
  - Proxy ARP if Dest EP is present locally on the host
- Src EP known, Dest EP not known:
  - ARP Request to a router/VM scenario. Reinject ARP request to uplinks
- Src EP not known, Dest EP known:
  - Proxy ARP if Dest EP is present locally on the host
- Src and Dest EP not known:
  - Ignore processing the request