### PR TITLE
Vxlan arp suppression

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -74,19 +74,19 @@
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/common",
-			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
+			"Rev": "a0fe038945ccf5c6d3e949d1607f0d47dc64ef60"
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/openflow13",
-			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
+			"Rev": "a0fe038945ccf5c6d3e949d1607f0d47dc64ef60"
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/protocol",
-			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
+			"Rev": "a0fe038945ccf5c6d3e949d1607f0d47dc64ef60"
 		},
 		{
 			"ImportPath": "github.com/shaleman/libOpenflow/util",
-			"Rev": "9febb448a0583ecbec2fc5f8fa0b56fb214d057b"
+			"Rev": "a0fe038945ccf5c6d3e949d1607f0d47dc64ef60"
 		},
 		{
 			"ImportPath": "github.com/vishvananda/netlink",

--- a/Godeps/_workspace/src/github.com/shaleman/libOpenflow/openflow13/action.go
+++ b/Godeps/_workspace/src/github.com/shaleman/libOpenflow/openflow13/action.go
@@ -311,6 +311,7 @@ func (a *ActionPush) UnmarshalBinary(data []byte) error {
     return nil
 }
 
+
 type ActionPopVlan struct {
     ActionHeader
     pad     []byte  // 4bytes
@@ -347,6 +348,37 @@ type ActionPopMpls struct {
     ActionHeader
     EtherType uint16
     pad     []byte  // 2bytes
+}
+
+
+func NewActionPopMpls(etherType uint16) *ActionPopMpls {
+    act := new(ActionPopMpls)
+    act.Type = ActionType_PopMpls
+    act.EtherType = etherType
+    act.Length = 8
+
+    return act
+}
+
+func (a *ActionPopMpls) Len() (n uint16) {
+    return a.ActionHeader.Len() + 4
+}
+
+func (a *ActionPopMpls) MarshalBinary() (data []byte, err error) {
+    data, err = a.ActionHeader.MarshalBinary()
+
+    // Padding
+    bytes := make([]byte, 4)
+    binary.BigEndian.PutUint16(bytes[0:], a.EtherType)
+
+    data = append(data, bytes...)
+    return
+}
+
+func (a *ActionPopMpls) UnmarshalBinary(data []byte) error {
+    a.ActionHeader.UnmarshalBinary(data[:4])
+    a.EtherType = binary.BigEndian.Uint16(data[4:])
+    return nil
 }
 
 type ActionSetField struct {

--- a/Godeps/_workspace/src/github.com/shaleman/libOpenflow/openflow13/match.go
+++ b/Godeps/_workspace/src/github.com/shaleman/libOpenflow/openflow13/match.go
@@ -218,20 +218,37 @@ func DecodeMatchField(class uint16, field uint8, data []byte) util.Message {
 		case OXM_FIELD_IPV6_ND_SLL:
 		case OXM_FIELD_IPV6_ND_TLL:
 		case OXM_FIELD_MPLS_LABEL:
+			val = new(MplsLabelField)
 		case OXM_FIELD_MPLS_TC:
 		case OXM_FIELD_MPLS_BOS:
+			val = new(MplsBosField)
 		case OXM_FIELD_PBB_ISID:
 		case OXM_FIELD_TUNNEL_ID:
 			val = new(TunnelIdField)
 		case OXM_FIELD_IPV6_EXTHDR:
 		case OXM_FIELD_TCP_FLAGS:
 			val = new(TcpFlagsField)
+		default:
+			log.Printf("Unhandled Field: %d in Class: %d", field, class)
+		}
+
+		val.UnmarshalBinary(data)
+		return val
+	} else if class == OXM_CLASS_NXM_1 {
+		var val util.Message
+		switch field {
+		case NXM_NX_TUN_IPV4_SRC:
+			val = new(TunnelIpv4SrcField)
+		case NXM_NX_TUN_IPV4_DST:
+			val = new(TunnelIpv4DstField)
+		default:
+			log.Printf("Unhandled Field: %d in Class: %d", field, class)
 		}
 
 		val.UnmarshalBinary(data)
 		return val
 	} else {
-		log.Panic("Unsupported match field class")
+		log.Panic("Unsupported match field: %d in class: %d", field, class)
 	}
 
 	return nil
@@ -294,6 +311,48 @@ const (
 	OXM_FIELD_IPV6_EXTHDR    = 39 /* IPv6 Extension Header pseudo-field */
 	OXM_FIELD_PBB_UCA        = 41 /* PBB UCA header field (from OpenFlow 1.4) */
 	OXM_FIELD_TCP_FLAGS      = 42 /* TCP flags (from OpenFlow 1.5) */
+)
+
+const (
+	NXM_NX_REG0          = 0
+	NXM_NX_REG1          = 1
+	NXM_NX_REG2          = 2
+	NXM_NX_REG3          = 3
+	NXM_NX_REG4          = 4
+	NXM_NX_REG5          = 5
+	NXM_NX_REG6          = 6
+	NXM_NX_REG7          = 7
+	NXM_NX_TUN_ID        = 16
+	NXM_NX_ARP_SHA       = 17
+	NXM_NX_ARP_THA       = 18
+	NXM_NX_IPV6_SRC      = 19
+	NXM_NX_IPV6_DST      = 20
+	NXM_NX_ICMPV6_TYPE   = 21
+	NXM_NX_ICMPV6_CODE   = 22
+	NXM_NX_ND_TARGET     = 23
+	NXM_NX_ND_SLL        = 24
+	NXM_NX_ND_TLL        = 25
+	NXM_NX_IP_FRAG       = 26
+	NXM_NX_IPV6_LABEL    = 27
+	NXM_NX_IP_ECN        = 28
+	NXM_NX_IP_TTL        = 29
+	NXM_NX_MPLS_TTL      = 30
+	NXM_NX_TUN_IPV4_SRC  = 31
+	NXM_NX_TUN_IPV4_DST  = 32
+	NXM_NX_PKT_MARK      = 33
+	NXM_NX_TCP_FLAGS     = 34
+	NXM_NX_DP_HASH       = 35
+	NXM_NX_RECIRC_ID     = 36
+	NXM_NX_CONJ_ID       = 37
+	NXM_NX_TUN_GBP_ID    = 38
+	NXM_NX_TUN_GBP_FLAGS = 39
+	NXM_NX_TUN_FLAGS     = 104
+	NXM_NX_CT_STATE      = 105
+	NXM_NX_CT_ZONE       = 106
+	NXM_NX_CT_MARK       = 107
+	NXM_NX_CT_LABEL      = 108
+	NXM_NX_TUN_IPV6_SRC  = 109
+	NXM_NX_TUN_IPV6_DST  = 110
 )
 
 // IN_PORT field
@@ -473,7 +532,7 @@ func (m *VlanIdField) UnmarshalBinary(data []byte) error {
 }
 
 // Return a MatchField for vlan id matching
-func NewVlanIdField(vlanId uint16) *MatchField {
+func NewVlanIdField(vlanId uint16, vlanMask *uint16) *MatchField {
 	f := new(MatchField)
 	f.Class = OXM_CLASS_OPENFLOW_BASIC
 	f.Field = OXM_FIELD_VLAN_VID
@@ -483,7 +542,83 @@ func NewVlanIdField(vlanId uint16) *MatchField {
 	vlanIdField.VlanId = vlanId | OFPVID_PRESENT
 	f.Value = vlanIdField
 	f.Length = uint8(vlanIdField.Len())
+	
+	if vlanMask != nil  { 
+		mask := new(VlanIdField)
+		mask.VlanId = *vlanMask
+		f.Mask = mask
+		f.HasMask = true
+		f.Length += uint8(mask.Len())
+	}
+	return f
+}
 
+// MplsLabel field 
+type MplsLabelField struct {
+	MplsLabel uint32
+}
+
+func (m *MplsLabelField) Len() uint16 {
+	return 4
+}
+
+func (m *MplsLabelField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 4)
+
+	binary.BigEndian.PutUint32(data, m.MplsLabel)
+	return
+}
+func (m *MplsLabelField) UnmarshalBinary(data []byte) error {
+	m.MplsLabel = binary.BigEndian.Uint32(data)
+	return nil
+}
+
+// Return a MatchField for mpls Label matching 
+func NewMplsLabelField(mplsLabel uint32) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_MPLS_LABEL
+	f.HasMask = false
+
+	mplsLabelField := new(MplsLabelField)
+	mplsLabelField.MplsLabel = mplsLabel 
+	f.Value = mplsLabelField
+	f.Length = uint8(mplsLabelField.Len())
+
+	return f
+}
+
+
+// MplsBos field 
+type MplsBosField struct {
+	MplsBos uint8
+}
+
+func (m *MplsBosField) Len() uint16 {
+	return 1
+}
+
+func (m *MplsBosField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 1)
+	data[0] = m.MplsBos
+	return
+}
+func (m *MplsBosField) UnmarshalBinary(data []byte) error {
+	m.MplsBos = data[0]
+	return nil
+}
+
+// Return a MatchField for mpls Bos matching 
+func NewMplsBosField(mplsBos uint8) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_MPLS_BOS
+	f.HasMask = false
+
+	mplsBosField := new(MplsBosField)
+	mplsBosField.MplsBos = mplsBos
+	f.Value = mplsBosField
+	f.Length = uint8(mplsBosField.Len())
 	return f
 }
 
@@ -835,6 +970,92 @@ func NewArpOperField(arpOper uint16) *MatchField {
 	arpOperField.ArpOper = arpOper
 	f.Value = arpOperField
 	f.Length = uint8(arpOperField.Len())
+
+	return f
+}
+
+// Tunnel IPv4 Src field
+type TunnelIpv4SrcField struct {
+	TunnelIpv4Src net.IP
+}
+
+func (m *TunnelIpv4SrcField) Len() uint16 {
+	return 4
+}
+func (m *TunnelIpv4SrcField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 4)
+	copy(data, m.TunnelIpv4Src.To4())
+	return
+}
+
+func (m *TunnelIpv4SrcField) UnmarshalBinary(data []byte) error {
+	m.TunnelIpv4Src = net.IPv4(data[0], data[1], data[2], data[3])
+	return nil
+}
+
+// Return a MatchField for tunnel ipv4 src addr
+func NewTunnelIpv4SrcField(tunnelIpSrc net.IP, tunnelIpSrcMask *net.IP) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_NXM_1
+	f.Field = NXM_NX_TUN_IPV4_SRC
+	f.HasMask = false
+
+	tunnelIpSrcField := new(TunnelIpv4SrcField)
+	tunnelIpSrcField.TunnelIpv4Src = tunnelIpSrc
+	f.Value = tunnelIpSrcField
+	f.Length = uint8(tunnelIpSrcField.Len())
+
+	// Add the mask
+	if tunnelIpSrcMask != nil {
+		mask := new(TunnelIpv4SrcField)
+		mask.TunnelIpv4Src = *tunnelIpSrcMask
+		f.Mask = mask
+		f.HasMask = true
+		f.Length += uint8(mask.Len())
+	}
+
+	return f
+}
+
+// Tunnel IPv4 Dst field
+type TunnelIpv4DstField struct {
+	TunnelIpv4Dst net.IP
+}
+
+func (m *TunnelIpv4DstField) Len() uint16 {
+	return 4
+}
+func (m *TunnelIpv4DstField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 4)
+	copy(data, m.TunnelIpv4Dst.To4())
+	return
+}
+
+func (m *TunnelIpv4DstField) UnmarshalBinary(data []byte) error {
+	m.TunnelIpv4Dst = net.IPv4(data[0], data[1], data[2], data[3])
+	return nil
+}
+
+// Return a MatchField for tunnel ipv4 dst addr
+func NewTunnelIpv4DstField(tunnelIpDst net.IP, tunnelIpDstMask *net.IP) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_NXM_1
+	f.Field = NXM_NX_TUN_IPV4_DST
+	f.HasMask = false
+
+	tunnelIpDstField := new(TunnelIpv4DstField)
+	tunnelIpDstField.TunnelIpv4Dst = tunnelIpDst
+	f.Value = tunnelIpDstField
+	f.Length = uint8(tunnelIpDstField.Len())
+
+	// Add the mask
+	if tunnelIpDstMask != nil {
+		mask := new(TunnelIpv4DstField)
+		mask.TunnelIpv4Dst = *tunnelIpDstMask
+		f.Mask = mask
+		f.HasMask = true
+		f.Length += uint8(mask.Len())
+	}
 
 	return f
 }

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -140,7 +140,7 @@ func (self *Flow) xlateMatch() openflow13.Match {
 
 	// Handle Vlan id
 	if self.Match.VlanId != 0 {
-		vidField := openflow13.NewVlanIdField(self.Match.VlanId)
+		vidField := openflow13.NewVlanIdField(self.Match.VlanId, nil)
 		ofMatch.AddField(*vidField)
 	}
 
@@ -244,7 +244,7 @@ func (self *Flow) installFlowActions(flowMod *openflow13.FlowMod,
 			pushVlanAction := openflow13.NewActionPushVlan(0x8100)
 
 			// Set Outer vlan tag field
-			vlanField := openflow13.NewVlanIdField(flowAction.vlanId)
+			vlanField := openflow13.NewVlanIdField(flowAction.vlanId, nil)
 			setVlanAction := openflow13.NewActionSetField(*vlanField)
 
 			// Prepend push vlan & setvlan actions to existing instruction

--- a/ofnet_test.go
+++ b/ofnet_test.go
@@ -854,6 +854,26 @@ func TestVlanFlowEntry(t *testing.T) {
 	}
 }
 
+// Verify if the flow entries are installed on vlan bridge
+func TestVxlanFlowEntry(t *testing.T) {
+	for i := 0; i < NUM_AGENT; i++ {
+		brName := "vxlanBridge" + fmt.Sprintf("%d", i)
+
+		flowList, err := ofctlFlowDump(brName)
+		if err != nil {
+			t.Errorf("Error getting flow entries. Err: %v", err)
+		}
+
+		// Check if ARP Request redirect entry is installed
+		arpFlowMatch := fmt.Sprintf("priority=100,arp,arp_op=1 actions=CONTROLLER")
+		if !ofctlFlowMatch(flowList, 0, arpFlowMatch) {
+			t.Errorf("Could not find the route %s on ovs %s", arpFlowMatch, brName)
+			return
+		}
+		log.Infof("Found arp redirect flow %s on ovs %s", arpFlowMatch, brName)
+	}
+}
+
 // Wait for debug and cleanup
 func TestWaitAndCleanup(t *testing.T) {
 	time.Sleep(1 * time.Second)

--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -17,13 +17,14 @@ package ofnet
 // This file implements the vxlan bridging datapath
 
 import (
-	//"fmt"
 	"errors"
 	"net"
 	"net/rpc"
 	"strings"
 
 	"github.com/contiv/ofnet/ofctrl"
+	"github.com/shaleman/libOpenflow/openflow13"
+	"github.com/shaleman/libOpenflow/protocol"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -124,7 +125,21 @@ func (self *Vxlan) SwitchDisconnected(sw *ofctrl.OFSwitch) {
 
 // Handle incoming packet
 func (self *Vxlan) PacketRcvd(sw *ofctrl.OFSwitch, pkt *ofctrl.PacketIn) {
-	// Ignore all incoming packets for now
+	switch pkt.Data.Ethertype {
+	case 0x0806:
+		if (pkt.Match.Type == openflow13.MatchType_OXM) &&
+			(pkt.Match.Fields[0].Class == openflow13.OXM_CLASS_OPENFLOW_BASIC) &&
+			(pkt.Match.Fields[0].Field == openflow13.OXM_FIELD_IN_PORT) {
+			// Get the input port number
+			switch t := pkt.Match.Fields[0].Value.(type) {
+			case *openflow13.InPortField:
+				var inPortFld openflow13.InPortField
+				inPortFld = *t
+
+				self.processArp(pkt.Data, inPortFld.InPort)
+			}
+		}
+	}
 }
 
 // Add a local endpoint and install associated local route
@@ -567,12 +582,12 @@ func (vx *Vxlan) RemoveUplink(portNo uint32) error {
 
 // AddSvcSpec adds a service spec to proxy
 func (vx *Vxlan) AddSvcSpec(svcName string, spec *ServiceSpec) error {
-        return nil
+	return nil
 }
 
 // DelSvcSpec removes a service spec from proxy
 func (vx *Vxlan) DelSvcSpec(svcName string, spec *ServiceSpec) error {
-        return nil
+	return nil
 }
 
 // SvcProviderUpdate Service Proxy Back End update
@@ -627,6 +642,14 @@ func (self *Vxlan) initFgraph() error {
 	})
 	vlanMissFlow.Next(sw.DropAction())
 
+	// Redirect ARP Request packets to controller
+	arpFlow, _ := self.inputTable.NewFlow(ofctrl.FlowMatch{
+		Priority:  FLOW_MATCH_PRIORITY,
+		Ethertype: 0x0806,
+		ArpOper:   protocol.Type_Request,
+	})
+	arpFlow.Next(sw.SendToController())
+
 	// Drop all packets that miss mac dest lookup AND vlan flood lookup
 	floodMissFlow, _ := self.macDestTable.NewFlow(ofctrl.FlowMatch{
 		Priority: FLOW_MISS_PRIORITY,
@@ -635,4 +658,119 @@ func (self *Vxlan) initFgraph() error {
 
 	// Drop all
 	return nil
+}
+
+/*
+ * Process incoming ARP packets
+ * ARP request handling in various scenarios:
+ * Src and Dest EP known:
+ *      - Proxy ARP if Dest EP is present locally on the host
+ * Src EP known, Dest EP not known:
+ *      - ARP Request to a router/VM scenario. Reinject ARP request to VTEPs
+ * Src EP not known, Dest EP known:
+ *      - Proxy ARP if Dest EP is present locally on the host
+ * Src and Dest EP not known:
+ *      - Ignore processing the request
+ */
+func (self *Vxlan) processArp(pkt protocol.Ethernet, inPort uint32) {
+	switch t := pkt.Data.(type) {
+	case *protocol.ARP:
+		log.Debugf("Processing ARP packet on port %d: %+v", inPort, *t)
+		var arpIn protocol.ARP = *t
+
+		switch arpIn.Operation {
+		case protocol.Type_Request:
+			// Lookup the Source and Dest IP in the endpoint table
+			srcEp := self.agent.getEndpointByIp(arpIn.IPSrc)
+			dstEp := self.agent.getEndpointByIp(arpIn.IPDst)
+
+			// No information about the src or dest EP. Ignore processing.
+			if srcEp == nil && dstEp == nil {
+				log.Debugf("No information on source/destination. Ignoring ARP request.")
+				return
+			}
+			// If we know the dstEp to be present locally, send the Proxy ARP response
+			if dstEp != nil {
+				// Container to Container communication. Send proxy ARP response.
+				// Unknown node to Container communication
+				//   -> Send proxy ARP response only if Endpoint is local.
+				//   -> This is to avoid sending ARP responses from ofnet agent on multiple hosts
+				if srcEp != nil ||
+					(srcEp == nil && dstEp.OriginatorIp.String() == self.agent.localIp.String()) {
+					// Form an ARP response
+					arpPkt, _ := protocol.NewARP(protocol.Type_Reply)
+					arpPkt.HWSrc, _ = net.ParseMAC(dstEp.MacAddrStr)
+					arpPkt.IPSrc = arpIn.IPDst
+					arpPkt.HWDst = arpIn.HWSrc
+					arpPkt.IPDst = arpIn.IPSrc
+					log.Debugf("Sending Proxy ARP response: %+v", arpPkt)
+
+					// Build the ethernet packet
+					ethPkt := protocol.NewEthernet()
+					ethPkt.VLANID.VID = pkt.VLANID.VID
+					ethPkt.HWDst = arpPkt.HWDst
+					ethPkt.HWSrc = arpPkt.HWSrc
+					ethPkt.Ethertype = 0x0806
+					ethPkt.Data = arpPkt
+					log.Debugf("Sending Proxy ARP response Ethernet: %+v", ethPkt)
+
+					// Construct Packet out
+					pktOut := openflow13.NewPacketOut()
+					pktOut.Data = ethPkt
+					pktOut.AddAction(openflow13.NewActionOutput(inPort))
+
+					// Send the packet out
+					self.ofSwitch.Send(pktOut)
+
+					return
+				}
+			}
+			if srcEp != nil && dstEp == nil {
+				// ARP request from local container to unknown IP
+				// Reinject ARP to VTEP ports
+
+				ethPkt := protocol.NewEthernet()
+				ethPkt.HWDst = pkt.HWDst
+				ethPkt.HWSrc = pkt.HWSrc
+				ethPkt.Ethertype = 0x0806
+				ethPkt.Data = &arpIn
+
+				log.Infof("Received ARP request for unknown IP: %v."+
+					"Reinjecting ARP request Ethernet to VTEP ports: %+v", arpIn.IPDst, ethPkt)
+
+				// Packet out
+				pktOut := openflow13.NewPacketOut()
+				pktOut.InPort = inPort
+				pktOut.Data = ethPkt
+				for _, vtepPort := range self.agent.vtepTable {
+					log.Debugf("Sending to VTEP port: %+v", *vtepPort)
+					pktOut.AddAction(openflow13.NewActionOutput(*vtepPort))
+				}
+
+				// Send the packet out
+				self.ofSwitch.Send(pktOut)
+			}
+
+		case protocol.Type_Reply:
+			log.Debugf("Received ARP response packet: %+v from port %d", arpIn, inPort)
+
+			ethPkt := protocol.NewEthernet()
+			ethPkt.VLANID = pkt.VLANID
+			ethPkt.HWDst = pkt.HWDst
+			ethPkt.HWSrc = pkt.HWSrc
+			ethPkt.Ethertype = 0x0806
+			ethPkt.Data = &arpIn
+			log.Debugf("Sending ARP response Ethernet: %+v", ethPkt)
+
+			// Packet out
+			pktOut := openflow13.NewPacketOut()
+			pktOut.InPort = inPort
+			pktOut.Data = ethPkt
+			pktOut.AddAction(openflow13.NewActionOutput(openflow13.P_NORMAL))
+
+			log.Debugf("Reinjecting ARP reply packet: %+v", pktOut)
+			// Send it out
+			self.ofSwitch.Send(pktOut)
+		}
+	}
 }


### PR DESCRIPTION
Adding support to handle ARP requests in vxlanBridge mode.

 ARP request handling in various scenarios:
 - Src and Dest EP known:
       - Proxy ARP if Dest EP is present locally on the host
 - Src EP known, Dest EP not known:
       - ARP Request to a router/VM scenario. Reinject ARP request to VTEPs
 - Src EP not known, Dest EP known:
       - Proxy ARP if Dest EP is present locally on the host
 - Src and Dest EP not known:
       - Ignore processing the request