### PR TITLE
Fixing Proxy ARP for ACi-gw

### DIFF
--- a/ofnet.go
+++ b/ofnet.go
@@ -118,18 +118,19 @@ type OfnetNode struct {
 
 // OfnetEndpoint has info about an endpoint
 type OfnetEndpoint struct {
-	EndpointID    string    // Unique identifier for the endpoint
-	EndpointType  string    // Type of the endpoint "internal", "external" or "externalRoute"
-	EndpointGroup int       // Endpoint group identifier for policies.
-	IpAddr        net.IP    // IP address of the end point
-	IpMask        net.IP    // IP mask for the end point
-	Vrf           string    // IP address namespace
-	MacAddrStr    string    // Mac address of the end point(in string format)
-	Vlan          uint16    // Vlan Id for the endpoint
-	Vni           uint32    // Vxlan VNI
-	OriginatorIp  net.IP    // Originating switch
-	PortNo        uint32    // Port number on originating switch
-	Timestamp     time.Time // Timestamp of the last event
+	EndpointID        string    // Unique identifier for the endpoint
+	EndpointType      string    // Type of the endpoint "internal", "external" or "externalRoute"
+	EndpointGroup     int       // Endpoint group identifier for policies.
+	IpAddr            net.IP    // IP address of the end point
+	IpMask            net.IP    // IP mask for the end point
+	Vrf               string    // IP address namespace
+	MacAddrStr        string    // Mac address of the end point(in string format)
+	Vlan              uint16    // Vlan Id for the endpoint
+	Vni               uint32    // Vxlan VNI
+	OriginatorIp      net.IP    // Originating switch
+	PortNo            uint32    // Port number on originating switch
+	Timestamp         time.Time // Timestamp of the last event
+	EndpointGroupVlan uint16    // EnpointGroup Vlan, needed in non-Standalone mode of netplugin
 }
 
 // OfnetPolicyRule has security rule to be installed

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -385,19 +385,19 @@ func (self *OfnetAgent) AddLocalEndpoint(endpoint EndpointInfo) error {
 	}
 	// Build endpoint registry info
 	epreg := &OfnetEndpoint{
-		EndpointID:    epId,
-		EndpointType:  "internal",
-		EndpointGroup: endpoint.EndpointGroup,
-		IpAddr:        endpoint.IpAddr,
-		IpMask:        net.ParseIP("255.255.255.255"),
-		Vrf:           *vrf,
-		MacAddrStr:    endpoint.MacAddr.String(),
-		Vlan:          endpoint.Vlan,
-		Vni:           *vni,
-		OriginatorIp:  self.localIp,
-		PortNo:        endpoint.PortNo,
-		Timestamp:     time.Now(),
-		EndpointGroup: endpoint.EndpointGroup,
+		EndpointID:        epId,
+		EndpointType:      "internal",
+		EndpointGroup:     endpoint.EndpointGroup,
+		IpAddr:            endpoint.IpAddr,
+		IpMask:            net.ParseIP("255.255.255.255"),
+		Vrf:               *vrf,
+		MacAddrStr:        endpoint.MacAddr.String(),
+		Vlan:              endpoint.Vlan,
+		Vni:               *vni,
+		OriginatorIp:      self.localIp,
+		PortNo:            endpoint.PortNo,
+		Timestamp:         time.Now(),
+		EndpointGroupVlan: endpoint.EndpointGroupVlan,
 	}
 
 	// Call the datapath

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -81,12 +81,13 @@ type OfnetAgent struct {
 
 // local End point information
 type EndpointInfo struct {
-	PortNo        uint32
-	EndpointGroup int
-	MacAddr       net.HardwareAddr
-	Vlan          uint16
-	IpAddr        net.IP
-	Vrf           string
+	PortNo            uint32
+	EndpointGroup     int
+	MacAddr           net.HardwareAddr
+	Vlan              uint16
+	IpAddr            net.IP
+	Vrf               string
+	EndpointGroupVlan uint16
 }
 
 const FLOW_MATCH_PRIORITY = 100        // Priority for all match flows
@@ -391,6 +392,7 @@ func (self *OfnetAgent) AddLocalEndpoint(endpoint EndpointInfo) error {
 		OriginatorIp:  self.localIp,
 		PortNo:        endpoint.PortNo,
 		Timestamp:     time.Now(),
+		EndpointGroup: endpoint.EndpointGroup,
 	}
 
 	// Call the datapath

--- a/vlanBridge.go
+++ b/vlanBridge.go
@@ -462,7 +462,7 @@ func (vl *VlanBridge) processArp(pkt protocol.Ethernet, inPort uint32) {
 				// ARP request from local container to unknown IP
 				// Reinject ARP to uplinks
 				ethPkt := protocol.NewEthernet()
-				ethPkt.VLANID.VID = srcEp.Vlan
+				ethPkt.VLANID.VID = srcEp.EndpointGroupVlan
 				ethPkt.HWDst = pkt.HWDst
 				ethPkt.HWSrc = pkt.HWSrc
 				ethPkt.Ethertype = 0x0806


### PR DESCRIPTION
For a version : v0.1-04-11-2016.17-31-22.UTC , proxy ARP was broken for ACI-gw. We were not able to ping default gateway because of this. With this fix, issue has been resolved and we are now able to ping gateway.