### PR TITLE
infranw: cleanup pending remote endpoints gracefully on network delete

### DIFF
--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -562,10 +562,6 @@ func (self *OfnetAgent) RemoveNetwork(vlanId uint16, vni uint32, Gw string, Vrf 
 
 	delete(self.endpointDb, gwEpid)
 
-	// Clear the database
-	delete(self.vlanVniMap, vlanId)
-	delete(self.vniVlanMap, vni)
-
 	// make sure there are no endpoints still installed in this vlan
 	for _, endpoint := range self.endpointDb {
 		if (vni != 0) && (endpoint.Vni == vni) {
@@ -574,7 +570,7 @@ func (self *OfnetAgent) RemoveNetwork(vlanId uint16, vni uint32, Gw string, Vrf 
 			} else {
 				// Network delete arrived before other hosts cleanup endpoint
 				var resp bool
-				log.Errorf("Vlan %d still has routes, cleaning up. Route: %+v", vlanId, endpoint)
+				log.Warnf("Vlan %d still has routes, cleaning up. Route: %+v", vlanId, endpoint)
 				err := self.EndpointDel(endpoint, &resp)
 				if err != nil {
 					log.Errorf("Error uninstalling endpoint %+v. Err: %v", endpoint, err)
@@ -583,6 +579,11 @@ func (self *OfnetAgent) RemoveNetwork(vlanId uint16, vni uint32, Gw string, Vrf 
 			}
 		}
 	}
+
+	// Clear the database
+	delete(self.vlanVniMap, vlanId)
+	delete(self.vniVlanMap, vni)
+
 	// Call the datapath
 	return self.datapath.RemoveVlan(vlanId, vni, Vrf)
 }

--- a/ofnet_test.go
+++ b/ofnet_test.go
@@ -869,6 +869,153 @@ func TestVxlanFlowEntry(t *testing.T) {
 	}
 }
 
+// Test Vrouter Network Delete with Remote Endpoints
+func TestOfnetVrtrDeleteNwWithRemoteEP(t *testing.T) {
+	testVlan := 100
+	for iter := 0; iter < NUM_ITER; iter++ {
+
+		// Add Vrtr Network
+		for i := 0; i < NUM_AGENT; i++ {
+			err := vrtrAgents[i].AddNetwork(uint16(testVlan), uint32(testVlan), "", "default")
+			if err != nil {
+				t.Errorf("Error adding vlan %d. Err: %v", testVlan, err)
+				return
+			}
+		}
+
+		log.Infof("Finished adding network")
+
+		// Add Vrtr Endpoints
+		for i := 0; i < NUM_AGENT; i++ {
+			j := i + 1
+
+			macAddr, _ := net.ParseMAC(fmt.Sprintf("02:02:02:%02x:%02x:%02x", j, j, j))
+			ipAddr := net.ParseIP(fmt.Sprintf("10.10.%d.%d", j, j))
+			endpoint := EndpointInfo{
+				PortNo:  uint32(NUM_AGENT + 2),
+				MacAddr: macAddr,
+				Vlan:    uint16(testVlan),
+				IpAddr:  ipAddr,
+			}
+
+			log.Infof("Installing local vrouter endpoint: %+v", endpoint)
+
+			// Install the local endpoint
+			err := vrtrAgents[i].AddLocalEndpoint(endpoint)
+			if err != nil {
+				t.Fatalf("Error installing endpoint: %+v. Err: %v", endpoint, err)
+				return
+			}
+		}
+
+		log.Infof("Finished adding endpoints")
+
+		for i := 0; i < NUM_AGENT; i++ {
+			j := i + 1
+			macAddr, _ := net.ParseMAC(fmt.Sprintf("02:02:02:%02x:%02x:%02x", j, j, j))
+			ipAddr := net.ParseIP(fmt.Sprintf("10.10.%d.%d", j, j))
+			endpoint := EndpointInfo{
+				PortNo:  uint32(NUM_AGENT + 2),
+				MacAddr: macAddr,
+				Vlan:    uint16(testVlan),
+				IpAddr:  ipAddr,
+			}
+
+			log.Infof("Deleting local vrouter endpoint: %+v", endpoint)
+
+			// Install the local endpoint
+			err := vrtrAgents[i].RemoveLocalEndpoint(uint32(NUM_AGENT + 2))
+			if err != nil {
+				t.Fatalf("Error deleting endpoint: %+v. Err: %v", endpoint, err)
+				return
+			}
+
+			// Remove network before endpoint cleanup on other agents
+			err = vrtrAgents[i].RemoveNetwork(uint16(testVlan), uint32(testVlan), "", "default")
+			if err != nil {
+				t.Errorf("Error removing vlan %d. Err: %v", testVlan, err)
+				return
+			}
+
+		}
+
+		log.Infof("All networks are deleted")
+	}
+}
+
+// Test Vxlan Network Delete with Remote Endpoints
+func TestOfnetVxlanDeleteNwWithRemoteEP(t *testing.T) {
+	testVlan := 100
+	for iter := 0; iter < NUM_ITER; iter++ {
+		// Add vxlan network
+		for i := 0; i < NUM_AGENT; i++ {
+
+			// Add Vxlan Network and Endpoints
+			err := vxlanAgents[i].AddNetwork(uint16(testVlan), uint32(testVlan), "", "default")
+			if err != nil {
+				t.Errorf("Error adding vlan %d. Err: %v", testVlan, err)
+				return
+			}
+		}
+
+		// Add vxlan endpoints
+		for i := 0; i < NUM_AGENT; i++ {
+			j := i + 1
+
+			macAddr, _ := net.ParseMAC(fmt.Sprintf("02:02:02:%02x:%02x:%02x", j, j, j))
+			ipAddr := net.ParseIP(fmt.Sprintf("10.10.%d.%d", j, j))
+			endpoint := EndpointInfo{
+				PortNo:  uint32(NUM_AGENT + 2),
+				MacAddr: macAddr,
+				Vlan:    uint16(testVlan),
+				IpAddr:  ipAddr,
+			}
+
+			log.Infof("Installing local vxlan endpoint: %+v", endpoint)
+
+			// Install the local endpoint
+			err := vxlanAgents[i].AddLocalEndpoint(endpoint)
+			if err != nil {
+				t.Fatalf("Error installing endpoint: %+v. Err: %v", endpoint, err)
+				return
+			}
+		}
+
+		log.Infof("Finished adding network and endpoints")
+
+		for i := 0; i < NUM_AGENT; i++ {
+			j := i + 1
+			macAddr, _ := net.ParseMAC(fmt.Sprintf("02:02:02:%02x:%02x:%02x", j, j, j))
+			ipAddr := net.ParseIP(fmt.Sprintf("10.10.%d.%d", j, j))
+			endpoint := EndpointInfo{
+				PortNo:  uint32(NUM_AGENT + 2),
+				MacAddr: macAddr,
+				Vlan:    uint16(testVlan),
+				IpAddr:  ipAddr,
+			}
+
+			log.Infof("Deleting local vxlan endpoint: %+v", endpoint)
+
+			// Install the local endpoint
+			err := vxlanAgents[i].RemoveLocalEndpoint(uint32(NUM_AGENT + 2))
+			if err != nil {
+				t.Fatalf("Error deleting endpoint: %+v. Err: %v", endpoint, err)
+				return
+			}
+
+			// Remove network before endpoint cleanup on other agents
+			err = vxlanAgents[i].RemoveNetwork(uint16(testVlan), uint32(testVlan), "", "default")
+			if err != nil {
+				t.Errorf("Error removing vlan %d. Err: %v", testVlan, err)
+				return
+			}
+
+		}
+
+		log.Infof("All networks are deleted")
+	}
+}
+
 // Wait for debug and cleanup
 func TestWaitAndCleanup(t *testing.T) {
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
infra nw automatically creates endpoints on every node. When infra nw is deleted, netplugin has sufficient knowledge to cleanup only local endpoints. Remote endpoints synced via ofnet will still be pending in ofnet database, since not all nodes have received and processed infra nw delete to cleanup their endpoints. In this case, cleanup the remote endpoints gracefully in ofnet instead of crash.