### PR TITLE
Fixing L3 service load balancer test case

### DIFF
--- a/vrouter.go
+++ b/vrouter.go
@@ -638,6 +638,9 @@ func (self *Vrouter) processArp(pkt protocol.Ethernet, inPort uint32) {
 		case protocol.Type_Request:
 			// Lookup the Dest IP in the endpoint table
 			vlan := self.agent.portVlanMap[inPort]
+			if vlan == nil {
+				return
+			}
 			endpointId := self.agent.getEndpointIdByIpVlan(arpHdr.IPDst, *vlan)
 			endpoint := self.agent.endpointDb[endpointId]
 			if endpoint == nil {

--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -355,10 +355,11 @@ func (self *Vxlan) RemoveVtepPort(portNo uint32, remoteIp net.IP) error {
 	for _, vlan := range self.vlanDb {
 		// Walk all vlans and remove from flood lists
 		vlan.allFlood.RemoveOutput(output)
+
+		portVlanFlow := vlan.vtepVlanFlowDb[portNo]
+		portVlanFlow.Delete()
+		delete(vlan.vtepVlanFlowDb, portNo)
 	}
-
-	// FIXME: uninstall vlan-vni mapping.
-
 	return nil
 }
 


### PR DESCRIPTION
During  system tests. It was ovserved that port vlan flow was not clearned post netplugin restart . Subsequent iterations were failing with flow already exists error. 