### PR TITLE
Port Bonding changes

### DIFF
--- a/ofnet.go
+++ b/ofnet.go
@@ -67,10 +67,10 @@ type OfnetDatapath interface {
 	RemoveVlan(vlanId uint16, vni uint32, vrf string) error
 
 	//Add uplink port
-	AddUplink(portNo uint32, ifname string) error
+	AddUplink(uplinkPort *PortInfo) error
 
 	//Delete uplink port
-	RemoveUplink(portNo uint32) error
+	RemoveUplink(uplinkName string) error
 
 	//Inject GARPs
 	InjectGARPs(epgID int)
@@ -182,10 +182,10 @@ type OfnetProtoNeighborInfo struct {
 
 // OfnetProtoRouterInfo has local router info
 type OfnetProtoRouterInfo struct {
-	ProtocolType string // type of protocol
-	RouterIP     string // ip address of the router
-	VlanIntf     string // uplink L2 intf
-	As           string // As for Bgp protocol
+	ProtocolType string   // type of protocol
+	RouterIP     string   // ip address of the router
+	UplinkPort   PortInfo // uplink L2 intf
+	As           string   // As for Bgp protocol
 }
 
 // OfnetProtoRouteInfo contains a route
@@ -250,4 +250,37 @@ type OfnetEndpointStats struct {
 	VrfName    string                   // vrf name
 	PortStats  OfnetDatapathStats       // Aggregate port stats
 	SvcStats   map[string]OfnetSvcStats // Service level stats
+}
+
+type linkStatus int
+
+// LinkStatus maintains link up/down information
+const (
+	linkDown linkStatus = iota
+	linkUp
+)
+
+const (
+	// PortType - individual port
+	PortType = "individual"
+
+	// BondType - bonded port
+	BondType = "bond"
+)
+
+// LinkInfo maintains individual link information
+type LinkInfo struct {
+	Name       string
+	Port       *PortInfo
+	LinkStatus linkStatus
+	OfPort     uint32
+}
+
+// PortInfo maintains port information
+type PortInfo struct {
+	Name        string
+	Type        string
+	LinkStatus  linkStatus
+	MbrLinks    []*LinkInfo
+	ActiveLinks []*LinkInfo
 }

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -126,11 +126,9 @@ const (
 )
 
 // Create a new Ofnet agent and initialize it
-/*  routerInfo[0] -> Uplink nexthop interface
- */
 func NewOfnetAgent(bridgeName string, dpName string, localIp net.IP, rpcPort uint16,
-	ovsPort uint16, routerInfo ...string) (*OfnetAgent, error) {
-	log.Infof("Creating new ofnet agent for %s,%s,%d,%d,%d,%v \n", bridgeName, dpName, localIp, rpcPort, ovsPort, routerInfo)
+	ovsPort uint16, uplinkInfo []string) (*OfnetAgent, error) {
+	log.Infof("Creating new ofnet agent for %s,%s,%d,%d,%d,%v \n", bridgeName, dpName, localIp, rpcPort, ovsPort, uplinkInfo)
 	agent := new(OfnetAgent)
 
 	// Init params
@@ -190,7 +188,7 @@ func NewOfnetAgent(bridgeName string, dpName string, localIp net.IP, rpcPort uin
 		agent.datapath = NewVlrouter(agent, rpcServ)
 		agent.fwdMode = "routing"
 		agent.ovsDriver = ovsdbDriver.NewOvsDriver(bridgeName)
-		agent.protopath = NewOfnetBgp(agent, routerInfo)
+		agent.protopath = NewOfnetBgp(agent, uplinkInfo)
 	default:
 		log.Fatalf("Unknown Datapath %s", dpName)
 	}
@@ -814,15 +812,15 @@ func (self *OfnetAgent) RemoveNetwork(vlanId uint16, vni uint32, Gw string, Vrf 
 }
 
 // AddUplink adds an uplink to the switch
-func (self *OfnetAgent) AddUplink(portNo uint32, ifname string) error {
+func (self *OfnetAgent) AddUplink(uplinkPort *PortInfo) error {
 	// Call the datapath
-	return self.datapath.AddUplink(portNo, ifname)
+	return self.datapath.AddUplink(uplinkPort)
 }
 
 // RemoveUplink remove an uplink to the switch
-func (self *OfnetAgent) RemoveUplink(portNo uint32) error {
+func (self *OfnetAgent) RemoveUplink(uplinkName string) error {
 	// Call the datapath
-	return self.datapath.RemoveUplink(portNo)
+	return self.datapath.RemoveUplink(uplinkName)
 }
 
 // AddSvcSpec adds a service spec to proxy

--- a/ofnetPolicy_test.go
+++ b/ofnetPolicy_test.go
@@ -29,7 +29,7 @@ func TestPolicyAddDelete(t *testing.T) {
 	rpcPort := uint16(9600)
 	ovsPort := uint16(9601)
 	lclIP := net.ParseIP("10.10.10.10")
-	ofnetAgent, err := NewOfnetAgent("", "vrouter", lclIP, rpcPort, ovsPort)
+	ofnetAgent, err := NewOfnetAgent("", "vrouter", lclIP, rpcPort, ovsPort, nil)
 	if err != nil {
 		t.Fatalf("Error creating ofnet agent. Err: %v", err)
 	}

--- a/ofnetSvcProxy_test.go
+++ b/ofnetSvcProxy_test.go
@@ -277,7 +277,7 @@ func TestSvcProxyInterface(t *testing.T) {
 	rpcPort := uint16(9600)
 	ovsPort := uint16(9601)
 	lclIP := net.ParseIP("10.10.10.10")
-	ofnetAgent, err := NewOfnetAgent("", "vrouter", lclIP, rpcPort, ovsPort)
+	ofnetAgent, err := NewOfnetAgent("", "vrouter", lclIP, rpcPort, ovsPort, nil)
 	if err != nil {
 		t.Fatalf("Error creating ofnet agent. Err: %v", err)
 	}

--- a/ofnet_port_test.go
+++ b/ofnet_port_test.go
@@ -1,0 +1,225 @@
+package ofnet
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+var gblOfPort = 1
+
+func TestUplinkPortCreateDelete(t *testing.T) {
+	uplinkSinglePort := createPort("upPort")
+	uplinkBondedPort := createBondedPort("upBond", []string{"vvport311", "vvport312"})
+	// Check uplink port creation in vlan bridge mode
+	err := addUplink(vlanAgents[0], uplinkSinglePort)
+	if err != nil {
+		t.Fatalf("Uplink port creation failed for vlanagent: %+v", err)
+	}
+
+	err = delUplink(vlanAgents[0], uplinkSinglePort)
+	if err != nil {
+		t.Fatalf("Uplink port deletion failed for vlanagent: %+v", err)
+	}
+
+	// Check uplink bonded port creation in vlan bridge mode
+	err = addUplink(vlanAgents[0], uplinkBondedPort)
+	if err != nil {
+		t.Fatalf("Uplink bonded port creation failed for vlanagent: %+v", err)
+	}
+
+	err = delUplink(vlanAgents[0], uplinkBondedPort)
+	if err != nil {
+		t.Fatalf("Uplink bonded port deletion failed for vlanagent: %+v", err)
+	}
+
+	// Check uplink port creation in vlrouter mode
+	// In vlrouter mode, we currently support only one interface
+	err = addUplink(vlrtrAgents[0], uplinkSinglePort)
+	if err != nil {
+		t.Fatalf("Uplink port creation failed for vlrouter agent: %+v", err)
+	}
+
+	err = delUplink(vlrtrAgents[0], uplinkSinglePort)
+	if err != nil {
+		t.Fatalf("Uplink port deletion failed for vlrouter agent: %+v", err)
+	}
+
+	// Check uplink bonded port creation in vlrouter mode
+	err = addUplink(vlrtrAgents[0], uplinkBondedPort)
+	if err == nil {
+		t.Fatalf("Uplink port creation with multiple interfaces expected to fail for vlrouter agent: %+v", err)
+	}
+}
+
+func TestPortActiveLinksStateChange(t *testing.T) {
+	bondName := "upBond1"
+	linkNames := []string{"vvport321", "vvport322", "vvport323", "vvport324", "vvport325"}
+	uplinkBondedPort := createBondedPort(bondName, linkNames)
+
+	err := addUplink(vlanAgents[0], uplinkBondedPort)
+	if err != nil {
+		t.Fatalf("Uplink bonded port creation failed for vlanagent: %+v", err)
+	}
+
+	defer delUplink(vlanAgents[0], uplinkBondedPort)
+
+	vlanBr := vlanAgents[0].datapath.(*VlanBridge)
+	vlanUplink := vlanBr.GetUplink(bondName)
+
+	if len(linkNames) != len(vlanUplink.ActiveLinks) {
+		t.Fatalf("Num active links not equal to num interfaces added.")
+	}
+
+	err = setLinkUpDown(linkNames[0], linkDown)
+	if err != nil {
+		t.Errorf("Error setting link down for %s", linkNames[0])
+	}
+
+	// Wait for a few seconds for Link messages to be triggered and processed
+	time.Sleep(3 * time.Second)
+
+	if len(vlanUplink.ActiveLinks) != 4 {
+		t.Fatalf("Number of active links not updated after link down. %+v", vlanUplink)
+	}
+
+	// Check Active links on link bringup
+	err = setLinkUpDown(linkNames[0], linkUp)
+	if err != nil {
+		t.Errorf("Error setting link up for %s", linkNames[0])
+	}
+	// Wait for a few seconds for Link messages to be triggered and processed
+	time.Sleep(3 * time.Second)
+
+	if len(linkNames) != len(vlanUplink.ActiveLinks) {
+		t.Fatalf("Active links not updated after link bringup of %s", linkNames[0])
+	}
+}
+
+func createPort(portName string) *PortInfo {
+	var port PortInfo
+	link := LinkInfo{
+		Name:       portName,
+		OfPort:     uint32(gblOfPort),
+		LinkStatus: linkDown,
+		Port:       &port,
+	}
+
+	port = PortInfo{
+		Name:       portName,
+		Type:       PortType,
+		LinkStatus: linkDown,
+		MbrLinks:   []*LinkInfo{&link},
+	}
+
+	gblOfPort++
+	return &port
+}
+
+func createBondedPort(bondName string, linkNames []string) *PortInfo {
+	var links []*LinkInfo
+	var port PortInfo
+	for i := 0; i < len(linkNames); i++ {
+		link := &LinkInfo{
+			Name:       linkNames[i],
+			OfPort:     uint32(gblOfPort),
+			LinkStatus: linkDown,
+			Port:       &port,
+		}
+		links = append(links, link)
+		gblOfPort++
+	}
+
+	port = PortInfo{
+		Name:       bondName,
+		Type:       BondType,
+		LinkStatus: linkDown,
+		MbrLinks:   links,
+	}
+
+	return &port
+}
+
+// setLinkUpDown sets the individual physical interface status up/down
+func setLinkUpDown(linkName string, status linkStatus) error {
+	var err error
+	link := findLink(linkName)
+	if link == nil {
+		return fmt.Errorf("Could not find link: %s", linkName)
+	}
+
+	if status == linkUp {
+		err = netlink.LinkSetUp(link)
+	} else {
+		err = netlink.LinkSetDown(link)
+	}
+
+	return err
+}
+
+// findLink finds the physical interface entity
+func findLink(linkName string) netlink.Link {
+	list, _ := netlink.LinkList()
+	for _, l := range list {
+		if strings.EqualFold(l.Attrs().Name, linkName) {
+			return l
+		}
+	}
+	return nil
+}
+
+// addUplink adds a dummy uplink to ofnet agent
+func addUplink(ofa *OfnetAgent, uplinkPort *PortInfo) error {
+	for _, link := range uplinkPort.MbrLinks {
+		link := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:   link.Name,
+				TxQLen: 100,
+				MTU:    1500,
+			},
+			PeerName: link.Name + "peer",
+		}
+		netlink.LinkDel(link)
+		time.Sleep(100 * time.Millisecond)
+
+		if err := netlink.LinkAdd(link); err != nil {
+			return err
+		}
+	}
+
+	time.Sleep(time.Second)
+
+	// add it to ofnet
+	err := ofa.AddUplink(uplinkPort)
+	if err != nil {
+		return err
+	}
+
+	for _, link := range uplinkPort.MbrLinks {
+		setLinkUpDown(link.Name, linkUp)
+	}
+
+	time.Sleep(5 * time.Second)
+	return nil
+}
+
+// delUplink deletes an uplink from ofnet agent
+func delUplink(ofa *OfnetAgent, uplinkPort *PortInfo) error {
+	err := ofa.RemoveUplink(uplinkPort.Name)
+	if err != nil {
+		return fmt.Errorf("Error deleting uplink. Err: %v", err)
+	}
+
+	for _, mbrLink := range uplinkPort.MbrLinks {
+		link := findLink(mbrLink.Name)
+		// cleanup the uplink
+		if err := netlink.LinkDel(link); err != nil {
+			return fmt.Errorf("Error deleting link: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/ofnet_test.go
+++ b/ofnet_test.go
@@ -107,7 +107,7 @@ func TestMain(m *testing.M) {
 		rpcPort := uint16(VRTR_RPC_PORT + i)
 		ovsPort := uint16(VRTR_OVS_PORT + i)
 		lclIp := net.ParseIP(localIpList[i])
-		vrtrAgents[i], err = NewOfnetAgent(brName, "vrouter", lclIp, rpcPort, ovsPort)
+		vrtrAgents[i], err = NewOfnetAgent(brName, "vrouter", lclIp, rpcPort, ovsPort, nil)
 		if err != nil {
 			log.Fatalf("Error creating ofnet agent. Err: %v", err)
 		}
@@ -124,7 +124,7 @@ func TestMain(m *testing.M) {
 		ovsPort := uint16(VXLAN_OVS_PORT + i)
 		lclIp := net.ParseIP(localIpList[i])
 
-		vxlanAgents[i], err = NewOfnetAgent(brName, "vxlan", lclIp, rpcPort, ovsPort)
+		vxlanAgents[i], err = NewOfnetAgent(brName, "vxlan", lclIp, rpcPort, ovsPort, nil)
 		if err != nil {
 			log.Fatalf("Error creating ofnet agent. Err: %v", err)
 		}
@@ -141,7 +141,7 @@ func TestMain(m *testing.M) {
 		ovsPort := uint16(VLAN_OVS_PORT + i)
 		lclIp := net.ParseIP(localIpList[i])
 
-		vlanAgents[i], err = NewOfnetAgent(brName, "vlan", lclIp, rpcPort, ovsPort)
+		vlanAgents[i], err = NewOfnetAgent(brName, "vlan", lclIp, rpcPort, ovsPort, nil)
 		if err != nil {
 			log.Fatalf("Error creating ofnet agent. Err: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestMain(m *testing.M) {
 		portName := "inb0" + fmt.Sprintf("%d", i)
 		driver := ovsdbDriver.NewOvsDriver(brName)
 		driver.CreatePort(portName, "internal", uint(1+i))
-		vlrtrAgents[i], err = NewOfnetAgent(brName, "vlrouter", lclIp, rpcPort, ovsPort, portName)
+		vlrtrAgents[i], err = NewOfnetAgent(brName, "vlrouter", lclIp, rpcPort, ovsPort, []string{portName})
 		if err != nil {
 			log.Fatalf("Error creating ofnet agent. Err: %v", err)
 		}

--- a/ovsdbDriver/ovsdbDriver.go
+++ b/ovsdbDriver/ovsdbDriver.go
@@ -604,7 +604,7 @@ func (self *OvsDriver) GetOfpPortNo(intfName string) (uint32, error) {
 	for {
 		row, err := self.ovsClient.Transact("Open_vSwitch", selectOp)
 
-		if err == nil {
+		if err == nil && len(row) > 0 && len(row[0].Rows) > 0 {
 			value := row[0].Rows[0]["ofport"]
 			if reflect.TypeOf(value).Kind() == reflect.Float64 {
 				//retry few more time. Due to asynchronous call between

--- a/vrouter.go
+++ b/vrouter.go
@@ -826,13 +826,13 @@ func (self *Vrouter) RemoveRemoteIpv6Flow(endpoint *OfnetEndpoint) error {
 }
 
 // AddUplink adds an uplink to the switch
-func (vr *Vrouter) AddUplink(portNo uint32, ifname string) error {
+func (vr *Vrouter) AddUplink(uplinkPort *PortInfo) error {
 	// Nothing to do
 	return nil
 }
 
 // RemoveUplink remove an uplink to the switch
-func (vr *Vrouter) RemoveUplink(portNo uint32) error {
+func (vr *Vrouter) RemoveUplink(uplinkName string) error {
 	// Nothing to do
 	return nil
 }

--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -766,12 +766,12 @@ func (self *Vxlan) RemoveEndpoint(endpoint *OfnetEndpoint) error {
 }
 
 // AddUplink adds an uplink to the switch
-func (vx *Vxlan) AddUplink(portNo uint32, ifname string) error {
+func (vx *Vxlan) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
 // RemoveUplink remove an uplink to the switch
-func (vx *Vxlan) RemoveUplink(portNo uint32) error {
+func (vx *Vxlan) RemoveUplink(uplinkName string) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR includes changes to support Bonded port changes

Requirement:
Bonded port is required to support redundancy to uplink switches

Changes:
PortInfo maintains member interfaces information and their link status
Interface DB maintains InterfaceInfo
Uplink DB maintains uplink PortInfo
AddUplink/RemoveUplink API changes
VlanBridge monitors uplink interfaces and sends GARPs on first active interface bringup