### PR TITLE
build before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ start: update
 stop:
 	vagrant destroy -f
 
-test: start
+test: build 
 	vagrant ssh node1 -c 'cd /opt/gopath/src/github.com/contiv/ofnet && make host-test'
 
 host-build:


### PR DESCRIPTION
Executing make test without make build fails because of godep being absent. Build first, to make sure all required packages are in place and to ensure no compile errors exist