### PR TITLE
Update uplink API

### DIFF
--- a/ofnet.go
+++ b/ofnet.go
@@ -69,6 +69,9 @@ type OfnetDatapath interface {
 	//Add uplink port
 	AddUplink(uplinkPort *PortInfo) error
 
+	//Update uplink port
+	UpdateUplink(uplinkName string, update PortUpdates) error
+
 	//Delete uplink port
 	RemoveUplink(uplinkName string) error
 
@@ -203,9 +206,16 @@ type ArpModeT string
 const (
 	// ArpFlood - ARP packets will be flooded in this mode
 	ArpFlood ArpModeT = "flood"
-
 	// ArpProxy - ARP packets will be redirected to controller
 	ArpProxy ArpModeT = "proxy"
+
+	// PortType - individual port
+	PortType = "individual"
+	// BondType - bonded port
+	BondType = "bond"
+
+	// LacpUpdate - for port update info
+	LacpUpdate = "lacp-upd"
 )
 
 // OfnetGlobalConfig has global level configs for ofnet
@@ -263,14 +273,6 @@ const (
 	linkUp
 )
 
-const (
-	// PortType - individual port
-	PortType = "individual"
-
-	// BondType - bonded port
-	BondType = "bond"
-)
-
 // LinkInfo maintains individual link information
 type LinkInfo struct {
 	Name       string
@@ -286,4 +288,22 @@ type PortInfo struct {
 	LinkStatus  linkStatus
 	MbrLinks    []*LinkInfo
 	ActiveLinks []*LinkInfo
+}
+
+// PortUpdates maintains multiplae port update info
+type PortUpdates struct {
+	PortName string
+	Updates  []PortUpdate
+}
+
+// PortUpdate maintains information about port update
+type PortUpdate struct {
+	UpdateType string
+	UpdateInfo interface{}
+}
+
+// LACP update
+type LinkUpdateInfo struct {
+	LinkName   string
+	LacpStatus bool
 }

--- a/ofnetAgent.go
+++ b/ofnetAgent.go
@@ -819,6 +819,12 @@ func (self *OfnetAgent) AddUplink(uplinkPort *PortInfo) error {
 	return self.datapath.AddUplink(uplinkPort)
 }
 
+// UpdateUplink Updates an uplink to the switch
+func (self *OfnetAgent) UpdateUplink(uplinkName string, portUpds PortUpdates) error {
+	// Call the datapath
+	return self.datapath.UpdateUplink(uplinkName, portUpds)
+}
+
 // RemoveUplink remove an uplink to the switch
 func (self *OfnetAgent) RemoveUplink(uplinkName string) error {
 	// Call the datapath

--- a/vlrouter.go
+++ b/vlrouter.go
@@ -1115,6 +1115,11 @@ func (self *Vlrouter) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
+// UpdateUplink updates uplink info
+func (self *Vlrouter) UpdateUplink(uplinkName string, updates PortUpdates) error {
+	return nil
+}
+
 func (self *Vlrouter) RemoveUplink(uplinkName string) error {
 	uplinkPort := self.GetUplink(uplinkName)
 

--- a/vrouter.go
+++ b/vrouter.go
@@ -906,6 +906,11 @@ func (vr *Vrouter) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
+// UpdateUplink updates uplink info
+func (vr *Vrouter) UpdateUplink(uplinkName string, updates PortUpdates) error {
+	return nil
+}
+
 // RemoveUplink remove an uplink to the switch
 func (vr *Vrouter) RemoveUplink(uplinkName string) error {
 	// Nothing to do

--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -849,6 +849,11 @@ func (vx *Vxlan) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
+// UpdateUplink updates uplink info
+func (vx *Vxlan) UpdateUplink(uplinkName string, updates PortUpdates) error {
+	return nil
+}
+
 // RemoveUplink remove an uplink to the switch
 func (vx *Vxlan) RemoveUplink(uplinkName string) error {
 	return nil


### PR DESCRIPTION
This PR includes changes to add an UpdateUplink API. It can be used to handle any uplink updates. Currently, it used to handle LacpUpdates and update the active links in port bond. Handling member link updates will be a new PR.