### PR TITLE
Vagrantfile: bump box to centos73 v0.10.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,8 +45,8 @@ SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "contiv/centos72"
-    config.vm.box_version = "0.9.0"
+    config.vm.box = "contiv/centos73"
+    config.vm.box_version = "0.10.2"
     config.vm.provider 'virtualbox' do |v|
         v.linked_clone = true if Vagrant::VERSION >= "1.8.0"
     end


### PR DESCRIPTION
This PR bumps the Vagrant box to version 0.10.2. This box includes Go 1.7.6.