### PR TITLE
Handle vswitch reconnect gracefully (vxlan + bridge fwd mode)

### DIFF
--- a/vxlanBridge.go
+++ b/vxlanBridge.go
@@ -130,6 +130,26 @@ func (self *Vxlan) SwitchConnected(sw *ofctrl.OFSwitch) {
 	self.initFgraph()
 
 	log.Infof("Switch connected(vxlan)")
+
+	// If vlanDb is populated and switch is connected, this implies
+	// we reconnected to a switch again. In this case, we have to
+	// update the current vlan entry to use a new switch object
+	if len(self.vlanDb) != 0 {
+		for vlanId, vlan := range self.vlanDb {
+			log.Debugf(" Updating vlan %s switch object", vlanId)
+			var err error
+			vlan.localFlood, err = self.ofSwitch.NewFlood()
+			if err != nil {
+				log.Errorf("Unable to assign new switch to vlan %s local flood", vlanId)
+				return
+			}
+			vlan.allFlood, err = self.ofSwitch.NewFlood()
+			if err != nil {
+				log.Errorf("Unable to assign new switch to vlan %s all flood", vlanId)
+				return
+			}
+		}
+	}
 }
 
 // Handle switch disconnected notification


### PR DESCRIPTION
With vxlan bridge fwd mode, vxlanBridge will start the ovs switch object
in two of the vlan flooding objects (localFlood and allFlood). The switch object
is being populated when the first vxlan is assigned.

When user restart ovs switch, ofnet handle the reconnect which pass down the notification
to vxlanBridge object but it doesn't refresh the existing vlans to save the
new switch object. This causes netplugin stuck to talk to an unbuffered channel.

This patchset is to refresh vxlan entry to store new switch object
when ofnet handle ovs switch reconnection

Signed-off-by: Kahou Lei <kalei@cisco.com>