### PR TITLE
Add support for Nicira Openflow extension

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -35,19 +35,19 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/common",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/openflow13",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/protocol",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/util",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libovsdb",

--- a/ofctrl/fgraphEmptyElem.go
+++ b/ofctrl/fgraphEmptyElem.go
@@ -1,0 +1,26 @@
+package ofctrl
+
+import (
+	"github.com/contiv/libOpenflow/openflow13"
+)
+
+// This file implements the forwarding graph API for empty element. It will return
+// InstrActions as the value of GetFlowInstr, but without any reserved actions.
+
+type EmptyElem struct {
+}
+
+// Fgraph element type for the NXOutput
+func (self *EmptyElem) Type() string {
+	return "empty"
+}
+
+// instruction set for NXOutput element
+func (self *EmptyElem) GetFlowInstr() openflow13.Instruction {
+	instr := openflow13.NewInstrApplyActions()
+	return instr
+}
+
+func NewEmptyElem() *EmptyElem {
+	return new(EmptyElem)
+}

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -921,6 +921,13 @@ func (self *Flow) install() error {
 	return nil
 }
 
+// updateInstallStatus changes isInstalled value.
+func (self *Flow) UpdateInstallStatus(installed bool) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	self.isInstalled = installed
+}
+
 // Set Next element in the Fgraph. This determines what actions will be
 // part of the flow's instruction set
 func (self *Flow) Next(elem FgraphElem) error {

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -837,7 +837,7 @@ func (self *Flow) install() error {
 	if !self.isInstalled {
 		flowMod.Command = openflow13.FC_ADD
 	} else {
-		flowMod.Command = openflow13.FC_MODIFY
+		flowMod.Command = openflow13.FC_MODIFY_STRICT
 	}
 
 	// convert match fields to openflow 1.3 format
@@ -1477,7 +1477,7 @@ func (self *Flow) Delete() error {
 	if self.isInstalled {
 		// Create a flowmode entry
 		flowMod := openflow13.NewFlowMod()
-		flowMod.Command = openflow13.FC_DELETE
+		flowMod.Command = openflow13.FC_DELETE_STRICT
 		flowMod.TableId = self.Table.TableId
 		flowMod.Priority = self.Match.Priority
 		flowMod.Cookie = self.CookieID

--- a/ofctrl/fgraphGroup.go
+++ b/ofctrl/fgraphGroup.go
@@ -1,0 +1,107 @@
+package ofctrl
+
+import (
+	"github.com/contiv/libOpenflow/openflow13"
+)
+
+type GroupType int
+
+const (
+	GroupAll GroupType = iota
+	GroupSelect
+	GroupIndirect
+	GroupFF
+)
+
+type Group struct {
+	Switch      *OFSwitch
+	ID          uint32
+	GroupType   GroupType
+	Buckets     []*openflow13.Bucket
+	isInstalled bool
+}
+
+func (self *Group) Type() string {
+	return "group"
+}
+
+func (self *Group) GetFlowInstr() openflow13.Instruction {
+	groupInstr := openflow13.NewInstrApplyActions()
+	groupAct := openflow13.NewActionGroup(self.ID)
+	// Add group action to the instruction
+	groupInstr.AddAction(groupAct, false)
+	return groupInstr
+}
+
+func (self *Group) AddBuckets(buckets ...*openflow13.Bucket) {
+	if self.Buckets == nil {
+		self.Buckets = make([]*openflow13.Bucket, 0)
+	}
+	self.Buckets = append(self.Buckets, buckets...)
+	if self.isInstalled {
+		self.Install()
+	}
+}
+
+func (self *Group) ResetBuckets(buckets ...*openflow13.Bucket) {
+	self.Buckets = make([]*openflow13.Bucket, 0)
+	self.Buckets = append(self.Buckets, buckets...)
+	if self.isInstalled {
+		self.Install()
+	}
+}
+
+func (self *Group) Install() error {
+	groupMod := openflow13.NewGroupMod()
+	groupMod.GroupId = self.ID
+
+	switch self.GroupType {
+	case GroupAll:
+		groupMod.Type = openflow13.OFPGT_ALL
+	case GroupSelect:
+		groupMod.Type = openflow13.OFPGT_SELECT
+	case GroupIndirect:
+		groupMod.Type = openflow13.OFPGT_INDIRECT
+	case GroupFF:
+		groupMod.Type = openflow13.OFPGT_FF
+	}
+
+	for _, bkt := range self.Buckets {
+		// Add the bucket to group
+		groupMod.AddBucket(*bkt)
+	}
+
+	if self.isInstalled {
+		groupMod.Command = openflow13.OFPGC_MODIFY
+	}
+	self.Switch.Send(groupMod)
+
+	// Mark it as installed
+	self.isInstalled = true
+
+	return nil
+}
+
+func (self *Group) Delete() error {
+	groupMod := openflow13.NewGroupMod()
+	groupMod.GroupId = self.ID
+
+	if self.isInstalled {
+		groupMod.Command = openflow13.OFPGC_DELETE
+		self.Switch.Send(groupMod)
+	}
+
+	// Mark it as unInstalled
+	self.isInstalled = false
+
+	// Delete group from switch cache
+	return self.Switch.DeleteGroup(self.ID)
+}
+
+func newGroup(id uint32, groupType GroupType, ofSwitch *OFSwitch) *Group {
+	return &Group{
+		ID:        id,
+		GroupType: groupType,
+		Switch:    ofSwitch,
+	}
+}

--- a/ofctrl/fgraphGroup.go
+++ b/ofctrl/fgraphGroup.go
@@ -83,16 +83,14 @@ func (self *Group) Install() error {
 }
 
 func (self *Group) Delete() error {
-	groupMod := openflow13.NewGroupMod()
-	groupMod.GroupId = self.ID
-
 	if self.isInstalled {
+		groupMod := openflow13.NewGroupMod()
+		groupMod.GroupId = self.ID
 		groupMod.Command = openflow13.OFPGC_DELETE
 		self.Switch.Send(groupMod)
+		// Mark it as unInstalled
+		self.isInstalled = false
 	}
-
-	// Mark it as unInstalled
-	self.isInstalled = false
 
 	// Delete group from switch cache
 	return self.Switch.DeleteGroup(self.ID)

--- a/ofctrl/fgraphNXOutput.go
+++ b/ofctrl/fgraphNXOutput.go
@@ -1,0 +1,43 @@
+package ofctrl
+
+import "github.com/contiv/libOpenflow/openflow13"
+
+// This file implements the forwarding graph API for output to NX register element
+
+type NXOutput struct {
+	field      *openflow13.MatchField // Target OXM/OXX field
+	fieldRange *openflow13.NXRange    // Field range of target register to resubmit
+}
+
+// Fgraph element type for the NXOutput
+func (self *NXOutput) Type() string {
+	return "NxOutput"
+}
+
+// instruction set for NXOutput element
+func (self *NXOutput) GetFlowInstr() openflow13.Instruction {
+	outputInstr := openflow13.NewInstrApplyActions()
+	outputAct := self.GetNXOutputAction()
+	outputInstr.AddAction(outputAct, false)
+	return outputInstr
+}
+
+// Return a NXOutput action
+func (self *NXOutput) GetNXOutputAction() openflow13.Action {
+	ofsNbits := self.fieldRange.ToOfsBits()
+	targetField := self.field
+	// Create NX output Register action
+	return openflow13.NewOutputFromField(targetField, ofsNbits)
+}
+
+func NewNXOutput(name string, start int, end int) (*NXOutput, error) {
+	field, err := openflow13.FindFieldHeaderByName(name, false)
+	if err != nil {
+		return nil, err
+	}
+	fieldRange := openflow13.NewNXRange(start, end)
+	return &NXOutput{
+		field:      field,
+		fieldRange: fieldRange,
+	}, nil
+}

--- a/ofctrl/fgraphNXOutput.go
+++ b/ofctrl/fgraphNXOutput.go
@@ -5,8 +5,8 @@ import "github.com/contiv/libOpenflow/openflow13"
 // This file implements the forwarding graph API for output to NX register element
 
 type NXOutput struct {
-	field      *openflow13.MatchField // Target OXM/OXX field
-	fieldRange *openflow13.NXRange    // Field range of target register to resubmit
+	field      *openflow13.MatchField // Target OXM/NXM field
+	fieldRange *openflow13.NXRange    // Field range of target register to output
 }
 
 // Fgraph element type for the NXOutput

--- a/ofctrl/fgraphOutput.go
+++ b/ofctrl/fgraphOutput.go
@@ -44,6 +44,8 @@ func (self *Output) GetFlowInstr() openflow13.Instruction {
 		outputInstr.AddAction(outputAct, false)
 	case "normal":
 		fallthrough
+	case "inPort":
+		fallthrough
 	case "port":
 		outputAct := openflow13.NewActionOutput(self.portNo)
 		outputInstr.AddAction(outputAct, false)
@@ -65,9 +67,19 @@ func (self *Output) GetOutAction() openflow13.Action {
 		return outputAct
 	case "normal":
 		fallthrough
+	case "inPort":
+		fallthrough
 	case "port":
 		return openflow13.NewActionOutput(self.portNo)
 	}
 
 	return nil
+}
+
+func NewOutputInPort() *Output {
+	return &Output{outputType: "inPort", portNo: openflow13.P_IN_PORT}
+}
+
+func NewOutputNormal() *Output {
+	return &Output{outputType: "normal", portNo: openflow13.P_NORMAL}
 }

--- a/ofctrl/fgraphOutput.go
+++ b/ofctrl/fgraphOutput.go
@@ -83,3 +83,7 @@ func NewOutputInPort() *Output {
 func NewOutputNormal() *Output {
 	return &Output{outputType: "normal", portNo: openflow13.P_NORMAL}
 }
+
+func NewOutputPort(portNo uint32) *Output {
+	return &Output{outputType: "port", portNo: portNo}
+}

--- a/ofctrl/fgraphResubmit.go
+++ b/ofctrl/fgraphResubmit.go
@@ -1,0 +1,41 @@
+package ofctrl
+
+import "github.com/wenyingd/libOpenflow/openflow13"
+
+// This file implements the forwarding graph API for the resubmit element
+
+type Resubmit struct {
+	ofport    uint16 // target ofport to resubmit
+	nextTable uint8  // target table to resubmit
+}
+
+// Fgraph element type for the Resubmit
+func (self *Resubmit) Type() string {
+	return "Resubmit"
+}
+
+// instruction set for resubmit element
+func (self *Resubmit) GetFlowInstr() openflow13.Instruction {
+	outputInstr := openflow13.NewInstrApplyActions()
+	resubmitAct := self.GetResubmitAction()
+	outputInstr.AddAction(resubmitAct, false)
+	return outputInstr
+}
+
+// Return a resubmit action (Used as a last action by flows in the table pipeline)
+func (self *Resubmit) GetResubmitAction() openflow13.Action {
+	if self.ofport == 0 {
+		self.ofport = openflow13.OFPP_IN_PORT
+	}
+	if self.nextTable == 0 {
+		self.nextTable = openflow13.OFPTT_ALL
+	}
+	return openflow13.NewNXActionResubmitTableAction(self.ofport, self.nextTable)
+}
+
+func NewResubmit(inPort uint16, table uint8) *Resubmit {
+	return &Resubmit{
+		ofport:    inPort,
+		nextTable: table,
+	}
+}

--- a/ofctrl/fgraphResubmit.go
+++ b/ofctrl/fgraphResubmit.go
@@ -1,6 +1,6 @@
 package ofctrl
 
-import "github.com/wenyingd/libOpenflow/openflow13"
+import "github.com/contiv/libOpenflow/openflow13"
 
 // This file implements the forwarding graph API for the resubmit element
 
@@ -24,18 +24,20 @@ func (self *Resubmit) GetFlowInstr() openflow13.Instruction {
 
 // Return a resubmit action (Used as a last action by flows in the table pipeline)
 func (self *Resubmit) GetResubmitAction() openflow13.Action {
-	if self.ofport == 0 {
-		self.ofport = openflow13.OFPP_IN_PORT
-	}
-	if self.nextTable == 0 {
-		self.nextTable = openflow13.OFPTT_ALL
-	}
 	return openflow13.NewNXActionResubmitTableAction(self.ofport, self.nextTable)
 }
 
-func NewResubmit(inPort uint16, table uint8) *Resubmit {
-	return &Resubmit{
-		ofport:    inPort,
-		nextTable: table,
+func NewResubmit(inPort *uint16, table *uint8) *Resubmit {
+	resubmit := new(Resubmit)
+	if inPort == nil {
+		resubmit.ofport = openflow13.OFPP_IN_PORT
+	} else {
+		resubmit.ofport = *inPort
 	}
+	if table == nil {
+		resubmit.nextTable = openflow13.OFPTT_ALL
+	} else {
+		resubmit.nextTable = *table
+	}
+	return resubmit
 }

--- a/ofctrl/fgraphSwitch.go
+++ b/ofctrl/fgraphSwitch.go
@@ -103,6 +103,33 @@ func (self *OFSwitch) DefaultTable() *Table {
 	return self.tableDb[0]
 }
 
+// Create a new group. return an error if it already exists
+func (self *OFSwitch) NewGroup(groupId uint32, groupType GroupType) (*Group, error) {
+	// check if the table already exists
+	if self.groupDb[groupId] != nil {
+		return nil, errors.New("Group already exists")
+	}
+
+	// Create a new table
+	group := newGroup(groupId, groupType, self)
+	// Save it in the DB
+	self.groupDb[groupId] = group
+
+	return group, nil
+}
+
+// Delete a group.
+// Return an error if there are flows refer pointing at it
+func (self *OFSwitch) DeleteGroup(groupId uint32) error {
+	delete(self.groupDb, groupId)
+	return nil
+}
+
+// GetGroup Returns a group
+func (self *OFSwitch) GetGroup(groupId uint32) *Group {
+	return self.groupDb[groupId]
+}
+
 // Return a output graph element for the port
 func (self *OFSwitch) OutputPort(portNo uint32) (*Output, error) {
 	self.portMux.Lock()

--- a/ofctrl/fgraphTable.go
+++ b/ofctrl/fgraphTable.go
@@ -56,8 +56,6 @@ func (self *Table) NewFlow(match FlowMatch) (*Flow, error) {
 	flow.Table = self
 	flow.Match = match
 	flow.isInstalled = false
-	flow.FlowID = globalFlowID // FIXME: need a better id allocation
-	globalFlowID += 1
 	flow.flowActions = make([]*FlowAction, 0)
 
 	log.Debugf("Creating new flow for match: %+v", match)

--- a/ofctrl/message_result.go
+++ b/ofctrl/message_result.go
@@ -1,0 +1,29 @@
+package ofctrl
+
+type MessageResult struct {
+	succeed      bool
+	errType      uint16
+	errCode      uint16
+	experimenter int32
+	xID          uint32
+}
+
+func (r *MessageResult) IsSucceed() bool {
+	return r.succeed
+}
+
+func (r *MessageResult) GetErrorType() uint16 {
+	return r.errType
+}
+
+func (r *MessageResult) GetErrorCode() uint16 {
+	return r.errCode
+}
+
+func (r *MessageResult) GetExperimenterID() int32 {
+	return r.experimenter
+}
+
+func (r *MessageResult) GetXid() uint32 {
+	return r.xID
+}

--- a/ofctrl/ofSwitch.go
+++ b/ofctrl/ofSwitch.go
@@ -28,7 +28,7 @@ import (
 	cmap "github.com/streamrail/concurrent-map"
 )
 
-var	(
+var (
 	heartbeatInterval, _ = time.ParseDuration("3s")
 )
 
@@ -151,10 +151,10 @@ func (self *OFSwitch) switchConnected() {
 		defer timer.Stop()
 		for {
 			select {
-				case <-timer.C:
-					self.Send(openflow13.NewEchoRequest())
-				case <-self.heartbeatCh:
-					break
+			case <-timer.C:
+				self.Send(openflow13.NewEchoRequest())
+			case <-self.heartbeatCh:
+				break
 			}
 		}
 	}()

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -531,8 +531,8 @@ func TestMatchSetTunnelId(t *testing.T) {
 
 // TestMatchSetIpFields verifies match & set for ip fields
 func TestMatchSetIpFields(t *testing.T) {
-	ipSa := net.ParseIP("10.1.1.1")
-	ipDa := net.ParseIP("10.2.1.1")
+	ipSa := net.ParseIP("10.1.1.0")
+	ipDa := net.ParseIP("10.2.1.0")
 	ipAddrMask := net.ParseIP("255.255.255.0")
 	inPortFlow, err := ofActor.inputTable.NewFlow(FlowMatch{
 		Priority:  100,

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -412,8 +412,8 @@ func TestSetUnsetDscp(t *testing.T) {
 	}
 
 	// Set vlan and dscp
-	inPortFlow.SetVlan(1)
 	inPortFlow.SetDscp(23)
+	inPortFlow.SetVlan(1)
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -549,8 +549,8 @@ func TestMatchSetIpFields(t *testing.T) {
 	}
 
 	// Set ip src/dst
-	inPortFlow.SetIPField(net.ParseIP("20.1.1.1"), "Src")
 	inPortFlow.SetIPField(net.ParseIP("20.2.1.1"), "Dst")
+	inPortFlow.SetIPField(net.ParseIP("20.1.1.1"), "Src")
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -643,8 +643,8 @@ func TestMatchSetTcpFields(t *testing.T) {
 	}
 
 	// Set TCP src/dst
-	inPortFlow.SetL4Field(4000, "TCPSrc")
 	inPortFlow.SetL4Field(5000, "TCPDst")
+	inPortFlow.SetL4Field(4000, "TCPSrc")
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -686,8 +686,8 @@ func TestMatchSetUdpFields(t *testing.T) {
 	}
 
 	// Set TCP src/dst
-	inPortFlow.SetL4Field(4000, "UDPSrc")
 	inPortFlow.SetL4Field(5000, "UDPDst")
+	inPortFlow.SetL4Field(4000, "UDPSrc")
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -876,7 +876,7 @@ func testNXExtensionsWithOFApplication(ofApp OfActor, ovsBr *ovsdbDriver.OvsDriv
 		t.Errorf("Error installing inport flow. Err: %v", err)
 	}
 	matchStr := "priority=100,in_port=5"
-	actionStr := "conjunction(101,2/3),conjunction(100,2/5)"
+	actionStr := "conjunction(100,2/5),conjunction(101,2/3)"
 	tableID := int(ofApp.inputTable.TableId)
 	// verify metadata action exists
 	if !ofctlDumpFlowMatch(brName, tableID, matchStr, actionStr) {
@@ -940,13 +940,13 @@ func testNXExtensionsWithOFApplication(ofApp OfActor, ovsBr *ovsdbDriver.OvsDriv
 	rng4 := openflow13.NewNXRange(0, 31)
 	sMAC, _ := net.ParseMAC("11:11:11:11:11:22")
 	sIP := net.ParseIP("192.168.1.100")
-	_ = flow7.SetARPSpa(sIP)
-	_ = flow7.SetARPSha(sMAC)
-	_ = flow7.SetMacSa(sMAC)
-	_ = flow7.SetARPOper(2)
-	_ = flow7.MoveRegs("NXM_OF_ARP_SPA", "NXM_OF_ARP_TPA", rng4, rng4)
-	_ = flow7.MoveRegs("NXM_NX_ARP_SHA", "NXM_NX_ARP_THA", rng2, rng2)
 	_ = flow7.MoveRegs("NXM_OF_ETH_SRC", "NXM_OF_ETH_DST", rng2, rng2)
+	_ = flow7.MoveRegs("NXM_NX_ARP_SHA", "NXM_NX_ARP_THA", rng2, rng2)
+	_ = flow7.MoveRegs("NXM_OF_ARP_SPA", "NXM_OF_ARP_TPA", rng4, rng4)
+	_ = flow7.SetARPOper(2)
+	_ = flow7.SetMacSa(sMAC)
+	_ = flow7.SetARPSha(sMAC)
+	_ = flow7.SetARPSpa(sIP)
 	verifyFlowInstallAndDelete(t, flow7, NewOutputInPort(), brName, ofApp.inputTable.TableId,
 		"priority=100,arp,in_port=7,arp_op=1",
 		"move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:2->arp_op,set_field:11:11:11:11:11:22->eth_src,set_field:11:11:11:11:11:22->arp_sha,set_field:192.168.1.100->arp_spa,IN_PORT")

--- a/ofctrl/transaction.go
+++ b/ofctrl/transaction.go
@@ -1,0 +1,175 @@
+package ofctrl
+
+// The work flow to use transaction for sending multiple Openflow messages should be:
+// NewTransaction->Begin->AddFlow->Complete->Commit. Client could cancel the messages by calling Abort after the
+// transaction is complete and not commit.
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/contiv/libOpenflow/openflow13"
+	"github.com/contiv/libOpenflow/util"
+)
+
+type TransactionType uint16
+
+func (t TransactionType) getValue() uint16 {
+	return uint16(t)
+}
+
+const (
+	Atomic  = TransactionType(openflow13.OFPBCT_ATOMIC)
+	Ordered = TransactionType(openflow13.OFPBCT_ORDERED)
+)
+
+var uid uint32
+
+type Transaction struct {
+	ofSwitch       *OFSwitch
+	ID             uint32
+	flag           TransactionType
+	closed         bool
+	lock           sync.Mutex
+	successAdd     map[uint32]bool
+	controlReplyCh chan MessageResult
+	addErrorCh     chan MessageResult
+}
+
+// NewTransaction creates a transaction on the switch. It will assign a bundle ID, and sets the bundle flags.
+func (self *OFSwitch) NewTransaction(flag TransactionType) *Transaction {
+	tx := new(Transaction)
+	tx.ID = atomic.AddUint32(&uid, 1)
+	if flag == 0 {
+		tx.flag = Atomic
+	} else {
+		tx.flag = flag
+	}
+	tx.ofSwitch = self
+	tx.controlReplyCh = make(chan MessageResult)
+	return tx
+}
+
+func (tx *Transaction) getError(reply MessageResult) error {
+	errType := reply.GetErrorType()
+	errCode := reply.GetErrorCode()
+	if errType == openflow13.ET_EXPERIMENTER && errCode >= openflow13.BFC_UNKNOWN && errCode <= openflow13.BFC_BUNDLE_IN_PROCESS {
+		return openflow13.ParseBundleError(reply.GetErrorCode())
+	}
+	return fmt.Errorf("unsupported bundle error with type %d and code %d", errType, errCode)
+}
+
+func (tx *Transaction) sendControlRequest(xID uint32, msg util.Message) error {
+	tx.ofSwitch.subscribeMessage(xID, tx.controlReplyCh)
+	defer tx.ofSwitch.unSubscribeMessage(xID)
+	tx.ofSwitch.Send(msg)
+	reply := <-tx.controlReplyCh
+	if reply.IsSucceed() {
+		return nil
+	} else {
+		return tx.getError(reply)
+	}
+}
+
+func (tx *Transaction) newBundleControlMessage(msgType uint16) *openflow13.BundleControl {
+	message := openflow13.NewBundleControl()
+	message.Type = msgType
+	message.Flags = tx.flag.getValue()
+	message.BundleID = tx.ID
+	return message
+}
+
+func (tx *Transaction) createBundleAddMessage(f *Flow) (*openflow13.BundleAdd, error) {
+	message := openflow13.NewBundleAdd()
+	message.BundleID = tx.ID
+	message.Flags = tx.flag.getValue()
+	flowMod, err := f.getFlowModMessage()
+	if err != nil {
+		return nil, err
+	}
+	flowMod.Xid = message.Xid
+	message.Message = flowMod
+	return message, nil
+}
+
+// Begin opens a bundle configuration.
+func (tx *Transaction) Begin() error {
+	message := tx.newBundleControlMessage(openflow13.OFPBCT_OPEN_REQUEST)
+	err := tx.sendControlRequest(message.Xid, message)
+	if err != nil {
+		return err
+	}
+	tx.addErrorCh = make(chan MessageResult, 10)
+	tx.successAdd = make(map[uint32]bool)
+	tx.ofSwitch.subscribeMessage(tx.ID, tx.addErrorCh)
+	// Start a new goroutine to listen add error messages if received from OFSwitch.
+	go func() {
+		for {
+			select {
+			case reply := <-tx.addErrorCh:
+				if reply.xID == 0 {
+					// Remove add message error channel when the bundle is closed.
+					tx.ofSwitch.unSubscribeMessage(tx.ID)
+					return
+				} else if !reply.succeed {
+					// Remove failed add message from successAdd.
+					tx.lock.Lock()
+					delete(tx.successAdd, reply.xID)
+					tx.lock.Unlock()
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// AddFlow adds messages in the bundle.
+func (tx *Transaction) AddFlow(flow *Flow) error {
+	message, err := tx.createBundleAddMessage(flow)
+	if err != nil {
+		return err
+	}
+	tx.lock.Lock()
+	tx.successAdd[message.Xid] = true
+	tx.lock.Unlock()
+	tx.ofSwitch.Send(message)
+	return nil
+}
+
+// Complete closes the bundle configuration. It returns the number of successful messages added in the bundle.
+func (tx *Transaction) Complete() (int, error) {
+	if !tx.closed {
+		msg1 := tx.newBundleControlMessage(openflow13.OFPBCT_CLOSE_REQUEST)
+		if err := tx.sendControlRequest(msg1.Xid, msg1); err != nil {
+			return 0, err
+		}
+		close(tx.addErrorCh)
+		tx.closed = true
+	}
+	return len(tx.successAdd), nil
+}
+
+// Commit commits the bundle configuration. If transaction is not closed, it sends OFPBCT_CLOSE_REQUEST in advance.
+func (tx *Transaction) Commit() error {
+	if !tx.closed {
+		return fmt.Errorf("transaction %d is not complete", tx.ID)
+	}
+	msg := tx.newBundleControlMessage(openflow13.OFPBCT_COMMIT_REQUEST)
+	if err := tx.sendControlRequest(msg.Xid, msg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Abort discards the bundle configuration. If transaction is not closed, it sends OFPBCT_CLOSE_REQUEST in advance.
+func (tx *Transaction) Abort() error {
+	if !tx.closed {
+		return fmt.Errorf("transaction %d is not complete", tx.ID)
+	}
+	msg := tx.newBundleControlMessage(openflow13.OFPBCT_DISCARD_REQUEST)
+	if err := tx.sendControlRequest(msg.Xid, msg); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/action.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/action.go
@@ -55,7 +55,7 @@ func (a *ActionHeader) MarshalBinary() (data []byte, err error) {
 }
 
 func (a *ActionHeader) UnmarshalBinary(data []byte) error {
-	if len(data) != 4 {
+	if len(data) < int(a.Len()) {
 		return errors.New("The []byte the wrong size to unmarshal an " +
 			"ActionHeader message.")
 	}
@@ -65,7 +65,7 @@ func (a *ActionHeader) UnmarshalBinary(data []byte) error {
 }
 
 // Decode Action types.
-func DecodeAction(data []byte) Action {
+func DecodeAction(data []byte) (Action, error) {
 	t := binary.BigEndian.Uint16(data[:2])
 	var a Action
 	switch t {
@@ -94,16 +94,29 @@ func DecodeAction(data []byte) Action {
 	case ActionType_SetNwTtl:
 		a = new(ActionNwTtl)
 	case ActionType_DecNwTtl:
-		a = new(ActionHeader)
+		a = new(ActionDecNwTtl)
 	case ActionType_SetField:
 		a = new(ActionSetField)
 	case ActionType_PushPbb:
 		a = new(ActionPush)
 	case ActionType_PopPbb:
 		a = new(ActionHeader)
+	case ActionType_Experimenter:
+		// For Experimenter message, the length of action should be at least 10 bytes,
+		// including type(2 byte), length(2 byte), vendor(4 byte), and subtype(2 byte)
+		if len(data) < NxActionHeaderLength {
+			return nil, errors.New("the []byte is too short to decode OpenFlow experimenter message")
+		}
+		v := binary.BigEndian.Uint32(data[4:8])
+		if v == NxExperimenterID {
+			a = DecodeNxAction(data)
+		}
 	}
-	a.UnmarshalBinary(data)
-	return a
+	err := a.UnmarshalBinary(data)
+	if err != nil {
+		return a, err
+	}
+	return a, nil
 }
 
 // Action structure for OFPAT_OUTPUT, which sends packets out ’port’.
@@ -260,6 +273,39 @@ type ActionMplsTtl struct {
 	ActionHeader
 	MplsTtl uint8
 	pad     []byte // 3bytes
+}
+
+type ActionDecNwTtl struct {
+	ActionHeader
+	pad []byte // 4bytes
+}
+
+func NewActionDecNwTtl() *ActionDecNwTtl {
+	act := new(ActionDecNwTtl)
+	act.Type = ActionType_DecNwTtl
+	act.Length = 8
+	act.pad = make([]byte, 4)
+	return act
+}
+
+func (a *ActionDecNwTtl) Len() (n uint16) {
+	return a.ActionHeader.Len() + 4
+}
+
+func (a *ActionDecNwTtl) MarshalBinary() (data []byte, err error) {
+	data, err = a.ActionHeader.MarshalBinary()
+	if err != nil {
+		return
+	}
+
+	// Padding
+	bytes := make([]byte, 4)
+	data = append(data, bytes...)
+	return
+}
+
+func (a *ActionDecNwTtl) UnmarshalBinary(data []byte) error {
+	return a.ActionHeader.UnmarshalBinary(data[:4])
 }
 
 type ActionNwTtl struct {

--- a/vendor/github.com/contiv/libOpenflow/openflow13/group.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/group.go
@@ -198,7 +198,10 @@ func (b *Bucket) UnmarshalBinary(data []byte) error {
 	n += 4 // for padding
 
 	for n < int(b.Length) {
-		a := DecodeAction(data[n:])
+		a, err := DecodeAction(data[n:])
+		if err != nil {
+			return err
+		}
 		b.Actions = append(b.Actions, a)
 		n += int(a.Len())
 	}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/instruction.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/instruction.go
@@ -204,7 +204,10 @@ func (instr *InstrActions) UnmarshalBinary(data []byte) error {
 
 	n := 8
 	for n < int(instr.Length) {
-		act := DecodeAction(data[n:])
+		act, err := DecodeAction(data[n:])
+		if err != nil {
+			return err
+		}
 		instr.Actions = append(instr.Actions, act)
 		n += int(act.Len())
 	}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/match.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/match.go
@@ -2,6 +2,7 @@ package openflow13
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -18,12 +19,13 @@ type Match struct {
 
 // One match field TLV
 type MatchField struct {
-	Class   uint16
-	Field   uint8
-	HasMask bool
-	Length  uint8
-	Value   util.Message
-	Mask    util.Message
+	Class          uint16
+	Field          uint8
+	HasMask        bool
+	Length         uint8
+	ExperimenterID uint32
+	Value          util.Message
+	Mask           util.Message
 }
 
 func NewMatch() *Match {
@@ -103,6 +105,9 @@ func (m *Match) AddField(f MatchField) {
 
 func (m *MatchField) Len() (n uint16) {
 	n = 4
+	if m.ExperimenterID != 0 {
+		n += 4
+	}
 	n += m.Value.Len()
 	if m.HasMask {
 		n += m.Mask.Len()
@@ -160,6 +165,16 @@ func (m *MatchField) UnmarshalBinary(data []byte) error {
 	m.Length = data[n]
 	n += 1
 
+	if m.Class == OXM_CLASS_EXPERIMENTER {
+		experimenterID := binary.BigEndian.Uint32(data[n:])
+		if experimenterID == ONF_EXPERIMENTER_ID {
+			n += 4
+			m.ExperimenterID = experimenterID
+		} else {
+			return fmt.Errorf("Unsupported experimenter id: %d in class: %d ", experimenterID, m.Class)
+		}
+	}
+
 	if m.Value, err = DecodeMatchField(m.Class, m.Field, data[n:]); err != nil {
 		return err
 	}
@@ -171,6 +186,33 @@ func (m *MatchField) UnmarshalBinary(data []byte) error {
 		}
 		n += m.Mask.Len()
 	}
+	return err
+}
+
+func (m *MatchField) MarshalHeader() uint32 {
+	var maskData uint32
+	if m.HasMask {
+		maskData = 1 << 8
+	} else {
+		maskData = 0 << 8
+	}
+	return uint32(m.Class)<<16 | uint32(m.Field)<<9 | maskData | uint32(m.Length)
+}
+
+func (m *MatchField) UnmarshalHeader(data []byte) error {
+	var err error
+	if len(data) < int(4) {
+		err = fmt.Errorf("the []byte is too short to unmarshal MatchField header")
+		return err
+	}
+	n := 0
+	m.Class = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	fieldWithMask := data[n]
+	m.HasMask = fieldWithMask&1 == 1
+	m.Field = fieldWithMask >> 1
+	n += 1
+	m.Length = data[n] & 0xff
 	return err
 }
 
@@ -211,15 +253,21 @@ func DecodeMatchField(class uint16, field uint8, data []byte) (util.Message, err
 		case OXM_FIELD_UDP_DST:
 			val = new(PortField)
 		case OXM_FIELD_SCTP_SRC:
+			val = new(PortField)
 		case OXM_FIELD_SCTP_DST:
+			val = new(PortField)
 		case OXM_FIELD_ICMPV4_TYPE:
 		case OXM_FIELD_ICMPV4_CODE:
 		case OXM_FIELD_ARP_OP:
 			val = new(ArpOperField)
 		case OXM_FIELD_ARP_SPA:
+			val = new(ArpXPaField)
 		case OXM_FIELD_ARP_TPA:
+			val = new(ArpXPaField)
 		case OXM_FIELD_ARP_SHA:
+			val = new(ArpXHaField)
 		case OXM_FIELD_ARP_THA:
+			val = new(ArpXHaField)
 		case OXM_FIELD_IPV6_SRC:
 			val = new(Ipv6SrcField)
 		case OXM_FIELD_IPV6_DST:
@@ -250,24 +298,116 @@ func DecodeMatchField(class uint16, field uint8, data []byte) (util.Message, err
 			return nil, fmt.Errorf("Bad pkt class: %v field: %v data: %v", class, field, data)
 		}
 
-		val.UnmarshalBinary(data)
+		err := val.UnmarshalBinary(data)
+		if err != nil {
+			return nil, err
+		}
 		return val, nil
 	} else if class == OXM_CLASS_NXM_1 {
 		var val util.Message
 		switch field {
+		case NXM_NX_REG0:
+			val = new(Uint32Message)
+		case NXM_NX_REG1:
+			val = new(Uint32Message)
+		case NXM_NX_REG2:
+			val = new(Uint32Message)
+		case NXM_NX_REG3:
+			val = new(Uint32Message)
+		case NXM_NX_REG4:
+			val = new(Uint32Message)
+		case NXM_NX_REG5:
+			val = new(Uint32Message)
+		case NXM_NX_REG6:
+			val = new(Uint32Message)
+		case NXM_NX_REG7:
+			val = new(Uint32Message)
+		case NXM_NX_REG8:
+			val = new(Uint32Message)
+		case NXM_NX_REG9:
+			val = new(Uint32Message)
+		case NXM_NX_REG10:
+			val = new(Uint32Message)
+		case NXM_NX_REG11:
+			val = new(Uint32Message)
+		case NXM_NX_REG12:
+			val = new(Uint32Message)
+		case NXM_NX_REG13:
+			val = new(Uint32Message)
+		case NXM_NX_REG14:
+			val = new(Uint32Message)
+		case NXM_NX_REG15:
+			val = new(Uint32Message)
+		case NXM_NX_TUN_ID:
+		case NXM_NX_ARP_SHA:
+			val = new(ArpXHaField)
+		case NXM_NX_ARP_THA:
+			val = new(ArpXHaField)
+		case NXM_NX_IPV6_SRC:
+		case NXM_NX_IPV6_DST:
+		case NXM_NX_ICMPV6_TYPE:
+		case NXM_NX_ICMPV6_CODE:
+		case NXM_NX_ND_TARGET:
+		case NXM_NX_ND_SLL:
+		case NXM_NX_ND_TLL:
+		case NXM_NX_IP_FRAG:
+		case NXM_NX_IPV6_LABEL:
+		case NXM_NX_IP_ECN:
+		case NXM_NX_IP_TTL:
+		case NXM_NX_MPLS_TTL:
 		case NXM_NX_TUN_IPV4_SRC:
 			val = new(TunnelIpv4SrcField)
 		case NXM_NX_TUN_IPV4_DST:
 			val = new(TunnelIpv4DstField)
+		case NXM_NX_PKT_MARK:
+		case NXM_NX_TCP_FLAGS:
+		case NXM_NX_DP_HASH:
+		case NXM_NX_RECIRC_ID:
+		case NXM_NX_CONJ_ID:
+			val = new(Uint32Message)
+		case NXM_NX_TUN_GBP_ID:
+		case NXM_NX_TUN_GBP_FLAGS:
+		case NXM_NX_TUN_METADATA0:
+		case NXM_NX_TUN_METADATA1:
+		case NXM_NX_TUN_METADATA2:
+		case NXM_NX_TUN_METADATA3:
+		case NXM_NX_TUN_METADATA4:
+		case NXM_NX_TUN_METADATA5:
+		case NXM_NX_TUN_METADATA6:
+		case NXM_NX_TUN_METADATA7:
+		case NXM_NX_TUN_FLAGS:
+		case NXM_NX_CT_STATE:
+			val = new(Uint32Message)
+		case NXM_NX_CT_ZONE:
+			val = new(Uint16Message)
+		case NXM_NX_CT_MARK:
+			val = new(Uint32Message)
+		case NXM_NX_CT_LABEL:
+			val = new(CTLabel)
+		case NXM_NX_TUN_IPV6_SRC:
 		default:
 			log.Printf("Unhandled Field: %d in Class: %d", field, class)
 			return nil, fmt.Errorf("Bad pkt class: %v field: %v data: %v", class, field, data)
 		}
 
-		val.UnmarshalBinary(data)
+		err := val.UnmarshalBinary(data)
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
+	} else if class == OXM_CLASS_EXPERIMENTER {
+		var val util.Message
+		switch field {
+		case OXM_FIELD_TCP_FLAGS:
+			val = new(TcpFlagsField)
+		}
+		err := val.UnmarshalBinary(data)
+		if err != nil {
+			return nil, err
+		}
 		return val, nil
 	} else {
-		log.Panic("Unsupported match field: %d in class: %d", field, class)
+		log.Panicf("Unsupported match field: %d in class: %d", field, class)
 	}
 
 	return nil, nil
@@ -285,6 +425,8 @@ const (
 	OXM_CLASS_NXM_1          = 0x0001 /* Backward compatibility with NXM */
 	OXM_CLASS_OPENFLOW_BASIC = 0x8000 /* Basic class for OpenFlow */
 	OXM_CLASS_EXPERIMENTER   = 0xFFFF /* Experimenter class */
+
+	ONF_EXPERIMENTER_ID = 0x4f4e4600 /* ONF Experimenter ID */
 )
 
 const (
@@ -333,45 +475,61 @@ const (
 )
 
 const (
-	NXM_NX_REG0          = 0
-	NXM_NX_REG1          = 1
-	NXM_NX_REG2          = 2
-	NXM_NX_REG3          = 3
-	NXM_NX_REG4          = 4
-	NXM_NX_REG5          = 5
-	NXM_NX_REG6          = 6
-	NXM_NX_REG7          = 7
-	NXM_NX_TUN_ID        = 16
-	NXM_NX_ARP_SHA       = 17
-	NXM_NX_ARP_THA       = 18
-	NXM_NX_IPV6_SRC      = 19
-	NXM_NX_IPV6_DST      = 20
-	NXM_NX_ICMPV6_TYPE   = 21
-	NXM_NX_ICMPV6_CODE   = 22
-	NXM_NX_ND_TARGET     = 23
-	NXM_NX_ND_SLL        = 24
-	NXM_NX_ND_TLL        = 25
-	NXM_NX_IP_FRAG       = 26
-	NXM_NX_IPV6_LABEL    = 27
-	NXM_NX_IP_ECN        = 28
-	NXM_NX_IP_TTL        = 29
-	NXM_NX_MPLS_TTL      = 30
-	NXM_NX_TUN_IPV4_SRC  = 31
-	NXM_NX_TUN_IPV4_DST  = 32
-	NXM_NX_PKT_MARK      = 33
-	NXM_NX_TCP_FLAGS     = 34
+	NXM_NX_REG0          = 0  /* nicira extension: reg0 */
+	NXM_NX_REG1          = 1  /* nicira extension: reg1 */
+	NXM_NX_REG2          = 2  /* nicira extension: reg2 */
+	NXM_NX_REG3          = 3  /* nicira extension: reg3 */
+	NXM_NX_REG4          = 4  /* nicira extension: reg4 */
+	NXM_NX_REG5          = 5  /* nicira extension: reg5 */
+	NXM_NX_REG6          = 6  /* nicira extension: reg6 */
+	NXM_NX_REG7          = 7  /* nicira extension: reg7 */
+	NXM_NX_REG8          = 8  /* nicira extension: reg8 */
+	NXM_NX_REG9          = 9  /* nicira extension: reg9 */
+	NXM_NX_REG10         = 10 /* nicira extension: reg10 */
+	NXM_NX_REG11         = 11 /* nicira extension: reg11 */
+	NXM_NX_REG12         = 12 /* nicira extension: reg12 */
+	NXM_NX_REG13         = 13 /* nicira extension: reg13 */
+	NXM_NX_REG14         = 14 /* nicira extension: reg14 */
+	NXM_NX_REG15         = 15 /* nicira extension: reg15 */
+	NXM_NX_TUN_ID        = 16 /* nicira extension: tun_id, VNI */
+	NXM_NX_ARP_SHA       = 17 /* nicira extension: arp_sha, ARP Source Ethernet Address */
+	NXM_NX_ARP_THA       = 18 /* nicira extension: arp_tha, ARP Target Ethernet Address */
+	NXM_NX_IPV6_SRC      = 19 /* nicira extension: tun_ipv6_src, IPv6 source address */
+	NXM_NX_IPV6_DST      = 20 /* nicira extension: tun_ipv6_src, IPv6 destination address */
+	NXM_NX_ICMPV6_TYPE   = 21 /* nicira extension: icmpv6_type, ICMPv6 type */
+	NXM_NX_ICMPV6_CODE   = 22 /* nicira extension: icmpv6_code, ICMPv6 code */
+	NXM_NX_ND_TARGET     = 23 /* nicira extension: nd_target, ICMPv6 neighbor discovery source ethernet address*/
+	NXM_NX_ND_SLL        = 24 /* nicira extension: nd_sll, ICMPv6 neighbor discovery source ethernet address*/
+	NXM_NX_ND_TLL        = 25 /* nicira extension: nd_tll, ICMPv6 neighbor discovery target ethernet address */
+	NXM_NX_IP_FRAG       = 26 /* nicira extension: ip_frag, IP fragments */
+	NXM_NX_IPV6_LABEL    = 27 /* nicira extension: ipv6_label, least 20 bits hold flow label from IPv6 header, others are zero*/
+	NXM_NX_IP_ECN        = 28 /* nicira extension: nw_ecn, TOS byte with DSCP bits cleared to 0 */
+	NXM_NX_IP_TTL        = 29 /* nicira extension: nw_ttl, time-to-live field */
+	NXM_NX_MPLS_TTL      = 30 /* nicira extension: mpls_ttl, time-to-live field from MPLS label */
+	NXM_NX_TUN_IPV4_SRC  = 31 /* nicira extension: tun_src, src IPv4 address of tunnel */
+	NXM_NX_TUN_IPV4_DST  = 32 /* nicira extension: tun_dst, dst IPv4 address of tunnel */
+	NXM_NX_PKT_MARK      = 33 /* nicira extension: pkg_mark, packet mark from Linux kernal */
+	NXM_NX_TCP_FLAGS     = 34 /* nicira extension: tcp_flags */
 	NXM_NX_DP_HASH       = 35
-	NXM_NX_RECIRC_ID     = 36
-	NXM_NX_CONJ_ID       = 37
-	NXM_NX_TUN_GBP_ID    = 38
-	NXM_NX_TUN_GBP_FLAGS = 39
-	NXM_NX_TUN_FLAGS     = 104
-	NXM_NX_CT_STATE      = 105
-	NXM_NX_CT_ZONE       = 106
-	NXM_NX_CT_MARK       = 107
-	NXM_NX_CT_LABEL      = 108
-	NXM_NX_TUN_IPV6_SRC  = 109
-	NXM_NX_TUN_IPV6_DST  = 110
+	NXM_NX_RECIRC_ID     = 36  /* nicira extension: recirc_id, used with ct */
+	NXM_NX_CONJ_ID       = 37  /* nicira extension: conj_id, conjunction ID for conjunctive match */
+	NXM_NX_TUN_GBP_ID    = 38  /* nicira extension: tun_gbp_id, GBP policy ID */
+	NXM_NX_TUN_GBP_FLAGS = 39  /* nicira extension: tun_gbp_flags, GBP policy Flags*/
+	NXM_NX_TUN_METADATA0 = 40  /* nicira extension: tun_metadata for Geneve header variable data */
+	NXM_NX_TUN_METADATA1 = 41  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA2 = 42  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA3 = 43  /* nicira extension: tun_metadata for Geneve header variable data */
+	NXM_NX_TUN_METADATA4 = 44  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA5 = 45  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA6 = 46  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA7 = 47  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_FLAGS     = 104 /* nicira extension: tunnel Flags */
+	NXM_NX_CT_STATE      = 105 /* nicira extension: ct_state for conn_track */
+	NXM_NX_CT_ZONE       = 106 /* nicira extension: ct_zone for conn_track */
+	NXM_NX_CT_MARK       = 107 /* nicira extension: ct_mark for conn_track */
+	NXM_NX_CT_LABEL      = 108 /* nicira extension: ct_label for conn_track */
+	NXM_NX_TUN_IPV6_SRC  = 109 /* nicira extension: tun_dst_ipv6, dst IPv6 address of tunnel */
+	NXM_NX_TUN_IPV6_DST  = 110 /* nicira extension: tun_dst_ipv6, src IPv6 address of tunnel */
 )
 
 // IN_PORT field
@@ -935,7 +1093,7 @@ func (m *MetadataField) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// Return a MatchField for tunel id matching
+// Return a MatchField for tunnel id matching
 func NewMetadataField(metadata uint64, metadataMask *uint64) *MatchField {
 	f := new(MatchField)
 	f.Class = OXM_CLASS_OPENFLOW_BASIC
@@ -1197,5 +1355,132 @@ func NewTunnelIpv4DstField(tunnelIpDst net.IP, tunnelIpDstMask *net.IP) *MatchFi
 		f.Length += uint8(mask.Len())
 	}
 
+	return f
+}
+
+// SCTP_DST field
+func NewSctpDstField(port uint16) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_SCTP_DST
+	f.HasMask = false
+
+	sctpDstField := new(PortField)
+	sctpDstField.port = port
+	f.Value = sctpDstField
+	f.Length = uint8(sctpDstField.Len())
+
+	return f
+}
+
+// SCTP_DST field
+func NewSctpSrcField(port uint16) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_SCTP_SRC
+	f.HasMask = false
+
+	sctpSrcField := new(PortField)
+	sctpSrcField.port = port
+	f.Value = sctpSrcField
+	f.Length = uint8(sctpSrcField.Len())
+
+	return f
+}
+
+// ARP Host Address field message, used by arp_sha and arp_tha match
+type ArpXHaField struct {
+	arpHa net.HardwareAddr
+}
+
+func (m *ArpXHaField) Len() uint16 {
+	return 6
+}
+func (m *ArpXHaField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	copy(data, m.arpHa)
+	return
+}
+
+func (m *ArpXHaField) UnmarshalBinary(data []byte) error {
+	if len(data) < int(m.Len()) {
+		return errors.New("The byte array has wrong size to unmarshal ArpXHaField message")
+	}
+	copy(m.arpHa, data[:6])
+	return nil
+}
+
+func NewArpThaField(arpTha net.HardwareAddr) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_ARP_THA
+	f.HasMask = false
+
+	arpThaField := new(ArpXHaField)
+	arpThaField.arpHa = arpTha
+	f.Value = arpThaField
+	f.Length = uint8(arpThaField.Len())
+	return f
+}
+
+func NewArpShaField(arpSha net.HardwareAddr) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_ARP_SHA
+	f.HasMask = false
+
+	arpXHAField := new(ArpXHaField)
+	arpXHAField.arpHa = arpSha
+	f.Value = arpXHAField
+	f.Length = uint8(arpXHAField.Len())
+	return f
+}
+
+// ARP Protocol Address field message, used by arp_spa and arp_tpa match
+type ArpXPaField struct {
+	ArpPa net.IP
+}
+
+func (m *ArpXPaField) Len() uint16 {
+	return 4
+}
+
+func (m *ArpXPaField) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	copy(data, m.ArpPa.To4())
+	return
+}
+
+func (m *ArpXPaField) UnmarshalBinary(data []byte) error {
+	if len(data) < int(m.Len()) {
+		return errors.New("The byte array has wrong size to unmarshal ArpXPaField message")
+	}
+	m.ArpPa = net.IPv4(data[0], data[1], data[2], data[3])
+	return nil
+}
+
+func NewArpTpaField(arpTpa net.IP) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_ARP_TPA
+	f.HasMask = false
+
+	arpTpaField := new(ArpXPaField)
+	arpTpaField.ArpPa = arpTpa
+	f.Value = arpTpaField
+	f.Length = uint8(arpTpaField.Len())
+	return f
+}
+
+func NewArpSpaField(arpSpa net.IP) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_ARP_SPA
+	f.HasMask = false
+
+	arpXPAField := new(ArpXPaField)
+	arpXPAField.ArpPa = arpSpa
+	f.Value = arpXPAField
+	f.Length = uint8(arpXPAField.Len())
 	return f
 }

--- a/vendor/github.com/contiv/libOpenflow/openflow13/nx_action.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/nx_action.go
@@ -1,0 +1,1005 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+)
+
+// NX Action constants
+const (
+	NxExperimenterID     = 0x00002320 // Vendor ID for Nicira extension messages
+	NxActionHeaderLength = 10         // Length of Nicira extension message header
+)
+
+// NX Action subtypes
+const (
+	NXAST_RESUBMIT         = 1  // Nicira extended action: resubmit(port)
+	NXAST_SET_TUNNEL       = 2  // Nicira extended action: set_tunnel
+	NXAST_DROP_SPOOFED_ARP = 3  // Nicira extended action: drop spoofed arp packets
+	NXAST_SET_QUEUE        = 4  // Nicira extended action: set_queue
+	NXAST_POP_QUEUE        = 5  // Nicira extended action: pop_tunnel
+	NXAST_REG_MOVE         = 6  // Nicira extended action: move:srcField[m1..n1]->dstField[m2..n2]
+	NXAST_REG_LOAD         = 7  // Nicira extended action: load:data->dstField[m..n]
+	NXAST_NOTE             = 8  // Nicira extended action: note
+	NXAST_SET_TUNNEL_V6    = 9  // Nicira extended action: set_tunnel64
+	NXAST_MULTIPATH        = 10 // Nicira extended action: set_tunnel
+	NXAST_AUTOPATH         = 11 // Nicira extended action: multipath
+	NXAST_BUNDLE           = 12 // Nicira extended action: bundle
+	NXAST_BUNDLE_LOAD      = 13 // Nicira extended action: bundle_load
+	NXAST_RESUBMIT_TABLE   = 14 // Nicira extended action: resubmit(port, table)
+	NXAST_OUTPUT_REG       = 15 // Nicira extended action: output:field
+	NXAST_LEARN            = 16 // Nicira extended action: learn
+	NXAST_EXIT             = 17 // Nicira extended action: exit
+	NXAST_DEC_TTL          = 18 // Nicira extended action: dec_ttl
+	NXAST_FIN_TIMEOUT      = 19 // Nicira extended action: output:field
+	NXAST_CONTROLLER       = 20 // Nicira extended action: fin_timeout
+	NXAST_DEC_TTL_CNT_IDS  = 21 // Nicira extended action: dec_ttl(id1,[id2]...)
+	NXAST_PUSH_MPLS        = 23 // Nicira extended action: push_mpls
+	NXAST_POP_MPLS         = 24 // Nicira extended action: pop_mpls
+	NXAST_SET_MPLS_TTL     = 25 // Nicira extended action: set_mpls_ttl
+	NXAST_DEC_MPLS_TTL     = 26 // Nicira extended action: set_mpls_ttl
+	NXAST_STACK_PUSH       = 27 // Nicira extended action: push:src
+	NXAST_STACK_POP        = 28 // Nicira extended action: pop:dst
+	NXAST_SAMPLE           = 29 // Nicira extended action: sample
+	NXAST_SET_MPLS_LABEL   = 30 // Nicira extended action: set_mpls_label
+	NXAST_SET_MPLS_TC      = 31 // Nicira extended action: set_mpls_tc
+	NXAST_OUTPUT_REG2      = 32 // Nicira extended action: output(port=port,max_len)
+	NXAST_REG_LOAD2        = 33 // Nicira extended action: load
+	NXAST_CONJUNCTION      = 34 // Nicira extended action: conjunction
+	NXAST_CT               = 35 // Nicira extended action: ct
+	NXAST_NAT              = 36 // Nicira extended action: nat, need to be along with ct action
+	NXAST_CONTROLLER2      = 37 // Nicira extended action: controller(userdata=xxx,pause)
+	NXAST_SAMPLE2          = 38 // Nicira extended action: sample, support for exporting egress tunnel
+	NXAST_OUTPUT_TRUNC     = 39 // Nicira extended action: truncate output action
+	NXAST_CT_CLEAR         = 43 // Nicira extended action: ct_clear
+	NXAST_CT_RESUBMIT      = 44 // Nicira extended action: resubmit to table in ct
+	NXAST_RAW_ENCAP        = 46 // Nicira extended action: encap
+	NXAST_RAW_DECAP        = 47 // Nicira extended action: decap
+	NXAST_DEC_NSH_TTL      = 48 // Nicira extended action: dec_nsh_ttl
+)
+
+type NXActionHeader struct {
+	*ActionHeader
+	Vendor  uint32
+	Subtype uint16
+}
+
+func (a *NXActionHeader) Header() *ActionHeader {
+	return a.ActionHeader
+}
+
+func (a *NXActionHeader) NXHeader() *NXActionHeader {
+	return a
+}
+
+func (a *NXActionHeader) Len() (n uint16) {
+	return NxActionHeaderLength
+}
+
+func (a *NXActionHeader) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, a.Len())
+	var b []byte
+	n := 0
+
+	b, err = a.ActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint32(data[n:], a.Vendor)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], a.Subtype)
+	return
+}
+
+func (a *NXActionHeader) UnmarshalBinary(data []byte) error {
+	if len(data) < int(NxActionHeaderLength) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionHeader message")
+	}
+	a.ActionHeader = new(ActionHeader)
+	n := 0
+	err := a.ActionHeader.UnmarshalBinary(data[:4])
+	n += 4
+	a.Vendor = binary.BigEndian.Uint32(data[n:])
+	n += 4
+	a.Subtype = binary.BigEndian.Uint16(data[n:])
+	return err
+}
+
+func NewNxActionHeader(subtype uint16) *NXActionHeader {
+	actionHeader := &ActionHeader{Type: ActionType_Experimenter, Length: NxActionHeaderLength}
+	return &NXActionHeader{ActionHeader: actionHeader, Vendor: NxExperimenterID, Subtype: subtype}
+}
+
+func DecodeNxAction(data []byte) Action {
+	var a Action
+	// Previous 8 bytes in the data includes type(2 byte), length(2 byte), and vendor(4 byte)
+	subtype := binary.BigEndian.Uint16(data[8:])
+	switch subtype {
+	case NXAST_RESUBMIT:
+		a = new(NXActionResubmit)
+	case NXAST_SET_TUNNEL:
+	case NXAST_DROP_SPOOFED_ARP:
+	case NXAST_SET_QUEUE:
+	case NXAST_POP_QUEUE:
+	case NXAST_REG_MOVE:
+		a = new(NXActionRegMove)
+	case NXAST_REG_LOAD:
+		a = new(NXActionRegLoad)
+	case NXAST_NOTE:
+	case NXAST_SET_TUNNEL_V6:
+	case NXAST_MULTIPATH:
+	case NXAST_AUTOPATH:
+	case NXAST_BUNDLE:
+	case NXAST_BUNDLE_LOAD:
+	case NXAST_RESUBMIT_TABLE:
+		a = new(NXActionResubmitTable)
+	case NXAST_OUTPUT_REG:
+		a = new(NXActionOutputReg)
+	case NXAST_LEARN:
+	case NXAST_EXIT:
+	case NXAST_DEC_TTL:
+		a = new(NXActionDecTTL)
+	case NXAST_FIN_TIMEOUT:
+	case NXAST_CONTROLLER:
+	case NXAST_DEC_TTL_CNT_IDS:
+		a = new(NXActionDecTTLCntIDs)
+	case NXAST_PUSH_MPLS:
+	case NXAST_POP_MPLS:
+	case NXAST_SET_MPLS_TTL:
+	case NXAST_DEC_MPLS_TTL:
+	case NXAST_STACK_PUSH:
+	case NXAST_STACK_POP:
+	case NXAST_SAMPLE:
+	case NXAST_SET_MPLS_LABEL:
+	case NXAST_SET_MPLS_TC:
+	case NXAST_OUTPUT_REG2:
+		a = new(NXActionOutputReg)
+	case NXAST_REG_LOAD2:
+	case NXAST_CONJUNCTION:
+		a = new(NXActionConjunction)
+	case NXAST_CT:
+		a = new(NXActionConnTrack)
+	case NXAST_NAT:
+		a = new(NXActionCTNAT)
+	case NXAST_CONTROLLER2:
+	case NXAST_SAMPLE2:
+	case NXAST_OUTPUT_TRUNC:
+	case NXAST_CT_CLEAR:
+	case NXAST_CT_RESUBMIT:
+		a = new(NXActionResubmitTable)
+		a.(*NXActionResubmitTable).withCT = true
+	case NXAST_RAW_ENCAP:
+	case NXAST_RAW_DECAP:
+	case NXAST_DEC_NSH_TTL:
+	}
+	return a
+}
+
+// NXActionConjunction is NX action to configure conjunctive match flows.
+type NXActionConjunction struct {
+	*NXActionHeader
+	Clause  uint8
+	NClause uint8
+	ID      uint32
+}
+
+// NewNXActionConjunction creates NXActionConjunction, the action in flow entry is like conjunction(ID, Clause/nclause).
+func NewNXActionConjunction(clause uint8, nclause uint8, id uint32) *NXActionConjunction {
+	a := new(NXActionConjunction)
+	a.NXActionHeader = NewNxActionHeader(NXAST_CONJUNCTION)
+	a.Length = a.NXActionHeader.Len() + 6
+	a.Clause = clause
+	a.NClause = nclause
+	a.ID = id
+	return a
+}
+
+func (a *NXActionConjunction) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionConjunction) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	data[n] = a.Clause
+	n++
+	data[n] = a.NClause
+	n++
+	binary.BigEndian.PutUint32(data[n:], a.ID)
+	n += 4
+
+	return
+}
+
+func (a *NXActionConjunction) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionConjunction message")
+	}
+	a.Clause = uint8(data[n])
+	n++
+	a.NClause = uint8(data[n])
+	n++
+	a.ID = binary.BigEndian.Uint32(data[n:])
+
+	return err
+}
+
+// NXActionConnTrack is NX action for conntrack.
+type NXActionConnTrack struct {
+	*NXActionHeader
+	Flags        uint16
+	ZoneSrc      uint32
+	ZoneOfsNbits uint16
+	RecircTable  uint8
+	pad          []byte // 3bytes
+	Alg          uint16
+	actions      []Action
+}
+
+func (a *NXActionConnTrack) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionConnTrack) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Length))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.Flags)
+	n += 2
+	binary.BigEndian.PutUint32(data[n:], a.ZoneSrc)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], a.ZoneOfsNbits)
+	n += 2
+	data[n] = a.RecircTable
+	n++
+	copy(data[n:], a.pad)
+	n += 3
+	binary.BigEndian.PutUint16(data[n:], a.Alg)
+	n += 2
+	// Marshal ct actions
+	for _, action := range a.actions {
+		actionBytes, err := action.MarshalBinary()
+		if err != nil {
+			return data, errors.New("failed to Marshal ct subActions")
+		}
+		copy(data[n:], actionBytes)
+		n += len(actionBytes)
+	}
+	return
+}
+
+func (a *NXActionConnTrack) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionConnTrack message")
+	}
+	a.Flags = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.ZoneSrc = binary.BigEndian.Uint32(data[n:])
+	n += 4
+	a.ZoneOfsNbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.RecircTable = data[n]
+	n++
+	copy(a.pad, data[n:n+3])
+	n += 3
+	a.Alg = binary.BigEndian.Uint16(data[n:])
+	n += 2
+
+	for n < int(a.Len()) {
+		act, err := DecodeAction(data[n:])
+		if err != nil {
+			return errors.New("failed to decode actions")
+		}
+		a.actions = append(a.actions, act)
+		n += int(act.Len())
+	}
+	a.Length = uint16(n)
+	return err
+}
+
+func (a *NXActionConnTrack) Commit() *NXActionConnTrack {
+	a.Flags |= NX_CT_F_COMMIT
+	return a
+}
+
+func (a *NXActionConnTrack) Force() *NXActionConnTrack {
+	a.Flags |= NX_CT_F_FORCE
+	return a
+}
+
+func (a *NXActionConnTrack) Table(tableID uint8) *NXActionConnTrack {
+	a.RecircTable = tableID
+	return a
+}
+
+func (a *NXActionConnTrack) ZoneImm(zoneID uint16) *NXActionConnTrack {
+	a.ZoneSrc = 0
+	a.ZoneOfsNbits = zoneID
+	return a
+}
+
+func (a *NXActionConnTrack) ZoneRange(field *MatchField, rng *NXRange) *NXActionConnTrack {
+	a.ZoneSrc = field.MarshalHeader()
+	a.ZoneOfsNbits = rng.ToOfsBits()
+	return a
+}
+
+func (a *NXActionConnTrack) AddAction(actions ...Action) *NXActionConnTrack {
+	for _, act := range actions {
+		a.actions = append(a.actions, act)
+		a.Length += act.Len()
+	}
+	return a
+}
+
+func NewNXActionConnTrack() *NXActionConnTrack {
+	a := new(NXActionConnTrack)
+	a.NXActionHeader = NewNxActionHeader(NXAST_CT)
+	a.Length = a.NXActionHeader.Len() + 14
+	a.RecircTable = NX_CT_RECIRC_NONE
+	return a
+}
+
+// NXActionRegLoad is NX action to load data to a specified field.
+type NXActionRegLoad struct {
+	*NXActionHeader
+	OfsNbits uint16
+	DstReg   *MatchField
+	Value    uint64
+}
+
+func NewNXActionRegLoad(ofsNbits uint16, dstField *MatchField, value uint64) *NXActionRegLoad {
+	a := new(NXActionRegLoad)
+	a.NXActionHeader = NewNxActionHeader(NXAST_REG_LOAD)
+	a.Length = a.NXActionHeader.Len() + 14
+	a.OfsNbits = ofsNbits
+	a.DstReg = dstField
+	a.Value = value
+	return a
+}
+
+func (a *NXActionRegLoad) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionRegLoad) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.OfsNbits)
+	n += 2
+	fieldHeaderData := a.DstReg.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], fieldHeaderData)
+	n += 4
+	binary.BigEndian.PutUint64(data[n:], a.Value)
+	n += 8
+
+	return
+}
+
+func (a *NXActionRegLoad) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionRegLoad message")
+	}
+	a.OfsNbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.DstReg = new(MatchField)
+	err = a.DstReg.UnmarshalHeader(data[n : n+4])
+	n += 4
+	a.Value = binary.BigEndian.Uint64(data[n:])
+	return err
+}
+
+// NXActionRegMove is NX action to move data from srcField to dstField.
+type NXActionRegMove struct {
+	*NXActionHeader
+	Nbits    uint16
+	SrcOfs   uint16
+	DstOfs   uint16
+	SrcField *MatchField
+	DstField *MatchField
+}
+
+func NewNXActionRegMove(nBits uint16, srcOfs uint16, dstOfs uint16, srcField *MatchField, dstField *MatchField) *NXActionRegMove {
+	a := new(NXActionRegMove)
+	a.NXActionHeader = NewNxActionHeader(NXAST_REG_MOVE)
+	a.Length = a.NXActionHeader.Len() + 14
+	a.Nbits = nBits
+	a.SrcOfs = srcOfs
+	a.DstOfs = dstOfs
+	a.SrcField = srcField
+	a.DstField = dstField
+	return a
+}
+
+func (a *NXActionRegMove) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionRegMove) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, a.Length)
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.Nbits)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.SrcOfs)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.DstOfs)
+	n += 2
+
+	srcFieldHeaderData := a.SrcField.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], srcFieldHeaderData)
+	n += 4
+
+	dstFieldHeaderData := a.DstField.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], dstFieldHeaderData)
+	n += 4
+	return
+}
+
+func (a *NXActionRegMove) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionRegLoad message")
+	}
+	a.Nbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.SrcOfs = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.DstOfs = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.SrcField = new(MatchField)
+	err = a.SrcField.UnmarshalHeader(data[n:])
+	n += 4
+	a.DstField = new(MatchField)
+	err = a.DstField.UnmarshalHeader(data[n:])
+	return err
+}
+
+// NXActionResubmit is NX action to resubmit packet to a specified in_port.
+type NXActionResubmit struct {
+	*NXActionHeader
+	InPort  uint16
+	TableID uint8
+	pad     [3]byte // 3 bytes
+}
+
+func NewNXActionResubmit(inPort uint16) *NXActionResubmit {
+	a := new(NXActionResubmit)
+	a.NXActionHeader = NewNxActionHeader(NXAST_RESUBMIT)
+	a.Type = Type_Experimenter
+	a.Length = a.NXActionHeader.Len() + 6
+	a.InPort = inPort
+	a.pad = [3]byte{}
+	return a
+}
+
+func (a *NXActionResubmit) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionResubmit) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.InPort)
+	n += 2
+	a.TableID = OFPTT_ALL
+	n++
+	// Skip padding copy, move the index.
+	n += 3
+
+	return
+}
+
+func (a *NXActionResubmit) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionConjunction message")
+	}
+	a.InPort = binary.BigEndian.Uint16(data[n:])
+
+	return err
+}
+
+// NXActionResubmitTable is NX action to resubmit packet to a specified table and in_port.
+type NXActionResubmitTable struct {
+	*NXActionHeader
+	InPort  uint16
+	TableID uint8
+	pad     [3]byte // 3 bytes
+	withCT  bool
+}
+
+func newNXActionResubmitTable() *NXActionResubmitTable {
+	a := &NXActionResubmitTable{
+		NXActionHeader: NewNxActionHeader(NXAST_RESUBMIT_TABLE),
+		withCT:         false,
+		pad:            [3]byte{},
+	}
+	a.Length = 16
+	return a
+}
+
+func newNXActionResubmitTableCT() *NXActionResubmitTable {
+	a := &NXActionResubmitTable{
+		NXActionHeader: NewNxActionHeader(NXAST_CT_RESUBMIT),
+		withCT:         true,
+		pad:            [3]byte{},
+	}
+	a.Length = 16
+	return a
+}
+
+func NewNXActionResubmitTableAction(inPort uint16, tableID uint8) *NXActionResubmitTable {
+	a := newNXActionResubmitTable()
+	a.InPort = inPort
+	a.TableID = tableID
+	return a
+}
+
+func (a *NXActionResubmitTable) IsCT() bool {
+	return a.withCT
+}
+
+func (a *NXActionResubmitTable) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionResubmitTable) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.InPort)
+	n += 2
+	data[n] = a.TableID
+	n++
+	// Skip padding copy, move the index.
+	n += 3
+
+	return
+}
+
+func (a *NXActionResubmitTable) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionResubmitTable message")
+	}
+	a.InPort = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.TableID = data[n]
+	n++
+	// Skip padding copy, move the index.
+	n += 3
+
+	return err
+}
+
+func NewNXActionResubmitTableCT(inPort uint16, tableID uint8) *NXActionResubmitTable {
+	a := newNXActionResubmitTableCT()
+	a.InPort = inPort
+	a.TableID = tableID
+	return a
+}
+
+func NewNXActionResubmitTableCTNoInPort(tableID uint8) *NXActionResubmitTable {
+	a := newNXActionResubmitTableCT()
+	a.InPort = OFPP_IN_PORT
+	a.TableID = tableID
+	return a
+}
+
+// NXActionCTNAT is NX action to set NAT in conntrack.
+type NXActionCTNAT struct {
+	*NXActionHeader
+	pad          []byte // 2 bytes
+	Flags        uint16 // nat Flags to identify snat/dnat, and nat algorithms: random/protocolHash, connection persistent
+	rangePresent uint16 // mark if has set nat range, including ipv4/ipv6 range, port range
+
+	rangeIPv4Min  net.IP
+	rangeIPv4Max  net.IP
+	rangeIPv6Min  net.IP
+	rangeIPv6Max  net.IP
+	rangeProtoMin *uint16
+	rangeProtoMax *uint16
+}
+
+func NewNXActionCTNAT() *NXActionCTNAT {
+	a := new(NXActionCTNAT)
+	a.NXActionHeader = NewNxActionHeader(NXAST_NAT)
+	a.Length = 16
+	a.pad = make([]byte, 2)
+	return a
+}
+
+func (a *NXActionCTNAT) Len() (n uint16) {
+	a.Length = ((a.Length + 7) / 8) * 8
+	return a.Length
+}
+
+func (a *NXActionCTNAT) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, a.Len())
+	b := make([]byte, a.NXActionHeader.Len())
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	// Skip padding bytes
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.Flags)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.rangePresent)
+	n += 2
+
+	if a.rangeIPv4Min != nil {
+		copy(data[n:], a.rangeIPv4Min.To4())
+		n += 4
+	}
+	if a.rangeIPv4Max != nil {
+		copy(data[n:], a.rangeIPv4Max.To4())
+		n += 4
+	}
+	if a.rangeIPv6Min != nil {
+		copy(data[n:], a.rangeIPv6Min.To16())
+		n += 16
+	}
+	if a.rangeIPv6Max != nil {
+		copy(data[n:], a.rangeIPv6Max.To16())
+		n += 16
+	}
+	if a.rangeProtoMin != nil {
+		binary.BigEndian.PutUint16(data[n:], *a.rangeProtoMin)
+		n += 2
+	}
+	if a.rangeProtoMin != nil {
+		binary.BigEndian.PutUint16(data[n:], *a.rangeProtoMax)
+		n += 2
+	}
+
+	return
+}
+
+func (a *NXActionCTNAT) SetSNAT() error {
+	if a.Flags&NX_NAT_F_DST != 0 {
+		return errors.New("the SNAT and DNAT actions should be mutually exclusive")
+	}
+	a.Flags |= NX_NAT_F_SRC
+	return nil
+}
+
+func (a *NXActionCTNAT) SetDNAT() error {
+	if a.Flags&NX_NAT_F_SRC != 0 {
+		return errors.New("the DNAT and SNAT actions should be mutually exclusive")
+	}
+	a.Flags |= NX_NAT_F_DST
+	return nil
+}
+
+func (a *NXActionCTNAT) SetProtoHash() error {
+	if a.Flags&NX_NAT_F_PROTO_RANDOM != 0 {
+		return errors.New("protocol hash and random should be mutually exclusive")
+	}
+	a.Flags |= NX_NAT_F_PROTO_HASH
+	return nil
+}
+
+func (a *NXActionCTNAT) SetRandom() error {
+	if a.Flags&NX_NAT_F_PROTO_HASH != 0 {
+		return errors.New("random and protocol hash should be mutually exclusive")
+	}
+	a.Flags |= NX_NAT_F_PROTO_RANDOM
+	return nil
+}
+
+func (a *NXActionCTNAT) SetPersistent() error {
+	a.Flags |= NX_NAT_F_PERSISTENT
+	return nil
+}
+
+func (a *NXActionCTNAT) SetRangeIPv4Min(ipMin net.IP) {
+	a.rangeIPv4Min = ipMin
+	a.rangePresent |= NX_NAT_RANGE_IPV4_MIN
+	a.Length += 4
+}
+func (a *NXActionCTNAT) SetRangeIPv4Max(ipMax net.IP) {
+	a.rangeIPv4Max = ipMax
+	a.rangePresent |= NX_NAT_RANGE_IPV4_MAX
+	a.Length += 4
+}
+func (a *NXActionCTNAT) SetRangeIPv6Min(ipMin net.IP) {
+	a.rangeIPv6Min = ipMin
+	a.rangePresent |= NX_NAT_RANGE_IPV6_MIN
+	a.Length += 16
+}
+func (a *NXActionCTNAT) SetRangeIPv6Max(ipMax net.IP) {
+	a.rangeIPv6Max = ipMax
+	a.rangePresent |= NX_NAT_RANGE_IPV6_MAX
+	a.Length += 16
+}
+func (a *NXActionCTNAT) SetRangeProtoMin(protoMin *uint16) {
+	a.rangeProtoMin = protoMin
+	a.rangePresent |= NX_NAT_RANGE_PROTO_MIN
+	a.Length += 2
+}
+func (a *NXActionCTNAT) SetRangeProtoMax(protoMax *uint16) {
+	a.rangeProtoMax = protoMax
+	a.rangePresent |= NX_NAT_RANGE_PROTO_MAX
+	a.Length += 2
+}
+
+func (a *NXActionCTNAT) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionCTNAT message")
+	}
+	// Skip padding bytes
+	n += 2
+	a.Flags = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.rangePresent = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	if a.rangePresent&NX_NAT_RANGE_IPV4_MIN != 0 {
+		a.rangeIPv4Min = net.IPv4(data[n], data[n+1], data[n+2], data[n+3])
+		n += 4
+	}
+	if a.rangePresent&NX_NAT_RANGE_IPV4_MAX != 0 {
+		a.rangeIPv4Max = net.IPv4(data[n], data[n+1], data[n+2], data[n+3])
+		n += 4
+	}
+	if a.rangePresent&NX_NAT_RANGE_IPV6_MIN != 0 {
+		a.rangeIPv6Min = make([]byte, 16)
+		copy(a.rangeIPv6Min, data[n:n+16])
+		n += 16
+	}
+	if a.rangePresent&NX_NAT_RANGE_IPV6_MAX != 0 {
+		a.rangeIPv6Max = make([]byte, 16)
+		copy(a.rangeIPv6Max, data[n:n+16])
+		n += 16
+	}
+	if a.rangePresent&NX_NAT_RANGE_PROTO_MIN != 0 {
+		portMin := binary.BigEndian.Uint16(data[n:])
+		a.rangeProtoMin = &portMin
+		n += 2
+	}
+	if a.rangePresent&NX_NAT_RANGE_PROTO_MAX != 0 {
+		portMax := binary.BigEndian.Uint16(data[n:])
+		a.rangeProtoMax = &portMax
+		n += 2
+	}
+
+	return err
+}
+
+// NXActionOutputReg is NX action to output to a field with a specified range.
+type NXActionOutputReg struct {
+	*NXActionHeader
+	OfsNbits uint16      // (ofs << 6 | (Nbits -1)
+	SrcField *MatchField // source nxm_nx_reg
+	MaxLen   uint16      // Max length to send to controller if chosen port is OFPP_CONTROLLER
+	zero     [6]uint8    // 6 uint8 with all Value as 0, reserved
+}
+
+func (a *NXActionOutputReg) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionOutputReg) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.OfsNbits)
+	n += 2
+	fieldHeaderData := a.SrcField.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], fieldHeaderData)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], a.MaxLen)
+	n += 2
+	copy(data[n:], a.zero[0:])
+	n += 6
+
+	return
+}
+
+func (a *NXActionOutputReg) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionOutputReg message")
+	}
+	a.OfsNbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.SrcField = new(MatchField)
+	err = a.SrcField.UnmarshalHeader(data[n : n+4])
+	n += 4
+	a.MaxLen = binary.BigEndian.Uint16(data[n:])
+	return err
+}
+
+func newNXActionOutputReg() *NXActionOutputReg {
+	a := &NXActionOutputReg{
+		NXActionHeader: NewNxActionHeader(NXAST_OUTPUT_REG),
+		zero:           [6]uint8{},
+	}
+	a.Length = 24
+	return a
+}
+
+func NewOutputFromField(srcField *MatchField, ofsNbits uint16) *NXActionOutputReg {
+	a := newNXActionOutputReg()
+	a.SrcField = srcField
+	a.OfsNbits = ofsNbits
+	a.MaxLen = uint16(0xffff)
+	return a
+}
+
+func NewOutputFromFieldWithMaxLen(srcField *MatchField, ofsNbits uint16, maxLen uint16) *NXActionOutputReg {
+	a := newNXActionOutputReg()
+	a.SrcField = srcField
+	a.OfsNbits = ofsNbits
+	a.MaxLen = maxLen
+	return a
+}
+
+type NXActionDecTTL struct {
+	*NXActionHeader
+	controllers uint16   // number of controller
+	zeros       [4]uint8 // 4 byte with zeros
+}
+
+func (a *NXActionDecTTL) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionDecTTL) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.controllers)
+	n += 2
+	copy(data[n:], a.zeros[0:])
+	return
+}
+
+func (a *NXActionDecTTL) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionRegLoad2 message")
+	}
+	a.controllers = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.zeros = [4]uint8{}
+	return err
+}
+
+func NewNXActionDecTTL() *NXActionDecTTL {
+	a := &NXActionDecTTL{
+		NXActionHeader: NewNxActionHeader(NXAST_DEC_TTL),
+		zeros:          [4]uint8{},
+	}
+	a.Length = 16
+	return a
+}
+
+type NXActionDecTTLCntIDs struct {
+	*NXActionHeader
+	controllers uint16   // number of controller
+	zeros       [4]uint8 // 4 byte with zeros
+	cntIDs      []uint16 // controller IDs
+}
+
+func (a *NXActionDecTTLCntIDs) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionDecTTLCntIDs) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	var b []byte
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.controllers)
+	n += 2
+	copy(data[n:], a.zeros[0:])
+	n += 4
+	for _, id := range a.cntIDs {
+		binary.BigEndian.PutUint16(data[n:], id)
+		n += 2
+	}
+	return
+}
+
+func (a *NXActionDecTTLCntIDs) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionDecTTLCntIDs message")
+	}
+	a.controllers = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.zeros = [4]uint8{}
+	n += 4
+	for i := 0; i < int(a.controllers); i++ {
+		id := binary.BigEndian.Uint16(data[n:])
+		a.cntIDs = append(a.cntIDs, id)
+		n += 2
+	}
+	return err
+}
+
+func NewNXActionDecTTLCntIDs(controllers uint16, ids ...uint16) *NXActionDecTTLCntIDs {
+	a := &NXActionDecTTLCntIDs{
+		NXActionHeader: NewNxActionHeader(NXAST_DEC_TTL_CNT_IDS),
+		controllers:    controllers,
+		zeros:          [4]uint8{},
+		cntIDs:         ids,
+	}
+	a.Length = 16 + uint16(2*len(ids))
+	return a
+}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/nx_match.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/nx_match.go
@@ -1,0 +1,310 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+)
+
+type Uint16Message struct {
+	data uint16
+}
+
+func newUint16Message(data uint16) *Uint16Message {
+	return &Uint16Message{data: data}
+}
+
+func (m *Uint16Message) Len() uint16 {
+	return 2
+}
+
+func (m *Uint16Message) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	binary.BigEndian.PutUint16(data, m.data)
+	return
+}
+
+func (m *Uint16Message) UnmarshalBinary(data []byte) error {
+	if len(data) < 2 {
+		return errors.New("the []byte is too short to unmarshal a full Uint16Message")
+	}
+	m.data = binary.BigEndian.Uint16(data[:2])
+	return nil
+}
+
+type Uint32Message struct {
+	data uint32
+}
+
+func newUint32Message(data uint32) *Uint32Message {
+	return &Uint32Message{data: data}
+}
+
+func (m *Uint32Message) Len() uint16 {
+	return 4
+}
+
+func (m *Uint32Message) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	binary.BigEndian.PutUint32(data, m.data)
+	return
+}
+
+func (m *Uint32Message) UnmarshalBinary(data []byte) error {
+	if len(data) < 4 {
+		return errors.New("the []byte is too short to unmarshal a full Uint32Message")
+	}
+	m.data = binary.BigEndian.Uint32(data[:4])
+	return nil
+}
+
+type CTStates struct {
+	data uint32
+	mask uint32
+}
+
+func NewCTStates() *CTStates {
+	return new(CTStates)
+}
+
+// SetNew sets ct_state as "+new".
+func (s *CTStates) SetNew() {
+	s.data |= 1 << 0
+	s.mask |= 1 << 0
+}
+
+// UnsetNew sets ct_state as "-new".
+func (s *CTStates) UnsetNew() {
+	s.data &^= 1 << NX_CT_STATE_NEW_OFS
+	s.mask |= 1 << NX_CT_STATE_NEW_OFS
+}
+
+// SetEst sets ct_state as "+est".
+func (s *CTStates) SetEst() {
+	s.data |= 1 << NX_CT_STATE_EST_OFS
+	s.mask |= 1 << NX_CT_STATE_EST_OFS
+}
+
+// UnsetEst sets ct_state as "-est".
+func (s *CTStates) UnsetEst() {
+	s.data &^= 1 << NX_CT_STATE_EST_OFS
+	s.mask |= 1 << NX_CT_STATE_EST_OFS
+}
+
+// SetRel sets ct_state as "+rel".
+func (s *CTStates) SetRel() {
+	s.data |= 1 << NX_CT_STATE_REL_OFS
+	s.mask |= 1 << NX_CT_STATE_REL_OFS
+}
+
+// UnsetRel sets ct_state as "-rel".
+func (s *CTStates) UnsetRel() {
+	s.data &^= 1 << NX_CT_STATE_REL_OFS
+	s.mask |= 1 << NX_CT_STATE_REL_OFS
+}
+
+// SetRpl sets ct_state as "+rpl".
+func (s *CTStates) SetRpl() {
+	s.data |= 1 << NX_CT_STATE_RPL_OFS
+	s.mask |= 1 << NX_CT_STATE_RPL_OFS
+}
+
+// UnsetRpl sets ct_state as "-rpl".
+func (s *CTStates) UnsetRpl() {
+	s.data &^= 1 << NX_CT_STATE_RPL_OFS
+	s.mask |= 1 << NX_CT_STATE_RPL_OFS
+}
+
+// SetInv sets ct_state as "+inv".
+func (s *CTStates) SetInv() {
+	s.data |= 1 << NX_CT_STATE_INV_OFS
+	s.mask |= 1 << NX_CT_STATE_INV_OFS
+}
+
+// UnsetInv sets ct_state as "-inv".
+func (s *CTStates) UnsetInv() {
+	s.data &^= 1 << NX_CT_STATE_INV_OFS
+	s.mask |= 1 << NX_CT_STATE_INV_OFS
+}
+
+// SetTrk sets ct_state as "+trk".
+func (s *CTStates) SetTrk() {
+	s.data |= 1 << NX_CT_STATE_TRK_OFS
+	s.mask |= 1 << NX_CT_STATE_TRK_OFS
+}
+
+// UnsetTrk sets ct_state as "-trk".
+func (s *CTStates) UnsetTrk() {
+	s.data &^= 1 << NX_CT_STATE_TRK_OFS
+	s.mask |= 1 << NX_CT_STATE_TRK_OFS
+}
+
+// SetSNAT sets ct_state as "+snat".
+func (s *CTStates) SetSNAT() {
+	s.data |= 1 << NX_CT_STATE_SNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
+}
+
+// UnsetSNAT sets ct_state as "-snat".
+func (s *CTStates) UnsetSNAT() {
+	s.data &^= 1 << NX_CT_STATE_SNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
+}
+
+// SetDNAT sets ct_state as "+dnat".
+func (s *CTStates) SetDNAT() {
+	s.data |= 1 << NX_CT_STATE_DNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_DNAT_OFS
+}
+
+// UnsetDNAT sets ct_state as "-dnat".
+func (s *CTStates) UnsetDNAT() {
+	s.data &^= 1 << NX_CT_STATE_DNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_DNAT_OFS
+}
+
+type NXRange struct {
+	start int
+	end   int
+}
+
+func newNXRegHeader(idx int, hasMask bool) *MatchField {
+	idKey := fmt.Sprintf("NXM_NX_REG%d", idx)
+	header, _ := FindFieldHeaderByName(idKey, hasMask)
+	return header
+}
+
+func NewRegMatchField(idx int, data uint32, dataRng *NXRange) *MatchField {
+	var field *MatchField
+	field = newNXRegHeader(idx, dataRng != nil)
+
+	field.Value = newUint32Message(data)
+	if dataRng != nil {
+		field.Mask = newUint32Message(dataRng.ToUint32Mask())
+	}
+	return field
+}
+
+func NewCTStateMatchField(states *CTStates) *MatchField {
+	field, _ := FindFieldHeaderByName("NXM_NX_CT_STATE", true)
+	field.Value = newUint32Message(states.data)
+	field.Mask = newUint32Message(states.mask)
+	return field
+}
+
+func NewCTZoneMatchField(zone uint16) *MatchField {
+	field, _ := FindFieldHeaderByName("NXM_NX_CT_ZONE", false)
+	field.Value = newUint16Message(zone)
+	return field
+}
+
+func NewCTMarkMatchField(mark uint32, mask *uint32) *MatchField {
+	var field *MatchField
+	field, _ = FindFieldHeaderByName("NXM_NX_CT_MARK", mask != nil)
+
+	field.Value = newUint32Message(mark)
+	if mask != nil {
+		field.Mask = newUint32Message(*mask)
+	}
+
+	return field
+}
+
+type CTLabel struct {
+	data [16]byte
+}
+
+func (m *CTLabel) Len() uint16 {
+	return uint16(len(m.data))
+}
+
+func (m *CTLabel) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	copy(data, m.data[:])
+	err = nil
+	return
+}
+
+func (m *CTLabel) UnmarshalBinary(data []byte) error {
+	m.data = [16]byte{}
+	if len(data) < len(m.data) {
+		copy(m.data[:], data)
+	} else {
+		copy(m.data[:], data[:16])
+	}
+	return nil
+}
+
+func newCTLabel(data [16]byte) *CTLabel {
+	label := new(CTLabel)
+	_ = label.UnmarshalBinary(data[:16])
+	return label
+}
+
+func NewCTLabelMatchField(label [16]byte, mask *[16]byte) *MatchField {
+	var field *MatchField
+	field, _ = FindFieldHeaderByName("NXM_NX_CT_LABEL", mask != nil)
+
+	field.Value = newCTLabel(label)
+	if mask != nil {
+		field.Mask = newCTLabel(*mask)
+	}
+
+	return field
+}
+
+func NewConjIDMatchField(conjID uint32) *MatchField {
+	field, _ := FindFieldHeaderByName("NXM_NX_CONJ_ID", false)
+	field.Value = newUint32Message(conjID)
+
+	return field
+}
+
+func NewNxARPShaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchField {
+	var field *MatchField
+	field, _ = FindFieldHeaderByName("NXM_NX_ARP_SHA", mask != nil)
+
+	field.Value = &ArpXHaField{arpHa: addr}
+	if mask != nil {
+		field.Mask = &ArpXHaField{arpHa: mask}
+	}
+
+	return field
+}
+
+func NewNxARPThaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchField {
+	var field *MatchField
+	field, _ = FindFieldHeaderByName("NXM_NX_ARP_THA", mask != nil)
+
+	field.Value = &ArpXHaField{arpHa: addr}
+	if mask != nil {
+		field.Mask = &ArpXHaField{arpHa: mask}
+	}
+
+	return field
+}
+
+func NewNxARPSpaMatchField(addr net.IP, mask net.IP) *MatchField {
+	var field *MatchField
+	field, _ = FindFieldHeaderByName("NXM_OF_ARP_SPA", mask != nil)
+
+	field.Value = &ArpXPaField{ArpPa: addr}
+	if mask != nil {
+		field.Mask = &ArpXPaField{ArpPa: mask}
+	}
+
+	return field
+}
+
+func NewNxARPTpaMatchField(addr net.IP, mask net.IP) *MatchField {
+	var field *MatchField
+	field, _ = FindFieldHeaderByName("NXM_OF_ARP_TPA", mask != nil)
+
+	field.Value = &ArpXPaField{ArpPa: addr}
+	if mask != nil {
+		field.Mask = &ArpXPaField{ArpPa: mask}
+	}
+
+	return field
+}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/nx_util.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/nx_util.go
@@ -1,0 +1,287 @@
+package openflow13
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// OFPP_IN_PORT is the default number of in_port field in resubmit actions.
+	OFPP_IN_PORT = 0xfff8
+)
+
+// NX_CT_STATES
+const (
+	NX_CT_STATE_NEW_OFS  = 0
+	NX_CT_STATE_EST_OFS  = 1
+	NX_CT_STATE_REL_OFS  = 2
+	NX_CT_STATE_RPL_OFS  = 3
+	NX_CT_STATE_INV_OFS  = 4
+	NX_CT_STATE_TRK_OFS  = 5
+	NX_CT_STATE_SNAT_OFS = 6
+	NX_CT_STATE_DNAT_OFS = 7
+)
+
+// NX_CT Flags
+const (
+	NX_CT_F_COMMIT    = 1 << 0
+	NX_CT_F_FORCE     = 1 << 1
+	NX_CT_RECIRC_NONE = 0xff
+)
+
+// NX_NAT_RANGE flags
+const (
+	NX_NAT_RANGE_IPV4_MIN  = 1 << 0
+	NX_NAT_RANGE_IPV4_MAX  = 1 << 1
+	NX_NAT_RANGE_IPV6_MIN  = 1 << 2
+	NX_NAT_RANGE_IPV6_MAX  = 1 << 3
+	NX_NAT_RANGE_PROTO_MIN = 1 << 4
+	NX_NAT_RANGE_PROTO_MAX = 1 << 5
+)
+
+// NX_NAT flags
+const (
+	NX_NAT_F_SRC          = 1 << 0
+	NX_NAT_F_DST          = 1 << 1
+	NX_NAT_F_PERSISTENT   = 1 << 2
+	NX_NAT_F_PROTO_HASH   = 1 << 3
+	NX_NAT_F_PROTO_RANDOM = 1 << 4
+	NX_NAT_F_MASK         = (NX_NAT_F_SRC | NX_NAT_F_DST | NX_NAT_F_PERSISTENT | NX_NAT_F_PROTO_HASH | NX_NAT_F_PROTO_RANDOM)
+)
+
+// NXM_OF fields. The class number of thses fields are 0x0000.
+const (
+	NXM_OF_IN_PORT uint8 = iota
+	NXM_OF_ETH_DST
+	NXM_OF_ETH_SRC
+	NXM_OF_ETH_TYPE
+	NXM_OF_VLAN_TCI
+	NXM_OF_IP_TOS
+	NXM_OF_IP_PROTO
+	NXM_OF_IP_SRC
+	NXM_OF_IP_DST
+	NXM_OF_TCP_SRC
+	NXM_OF_TCP_DST
+	NXM_OF_UDP_SRC
+	NXM_OF_UDP_DST
+	NXM_OF_ICMP_TYPE
+	NXM_OF_ICMP_CODE
+	NXM_OF_ARP_OP
+	NXM_OF_ARP_SPA
+	NXM_OF_ARP_TPA
+)
+
+func newMatchFieldHeader(class uint16, field uint8, length uint8) *MatchField {
+	var fieldLength = length
+	return &MatchField{Class: class, Field: field, Length: fieldLength, HasMask: false}
+}
+
+// oxxFieldHeaderMap is map to find target field header without mask using an OVS known OXX field name
+var oxxFieldHeaderMap = map[string]*MatchField{
+	"NXM_OF_IN_PORT":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IN_PORT, 2),
+	"NXM_OF_ETH_DST":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ETH_DST, 6),
+	"NXM_OF_ETH_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ETH_SRC, 6),
+	"NXM_OF_ETH_TYPE":  newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ETH_TYPE, 2),
+	"NXM_OF_VLAN_TCI":  newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_VLAN_TCI, 2),
+	"NXM_OF_IP_TOS":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_TOS, 1),
+	"NXM_OF_IP_PROTO":  newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_PROTO, 1),
+	"NXM_OF_IP_SRC":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_SRC, 4),
+	"NXM_OF_IP_DST":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_DST, 4),
+	"NXM_OF_TCP_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_TCP_SRC, 2),
+	"NXM_OF_TCP_DST":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_TCP_DST, 2),
+	"NXM_OF_UDP_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_UDP_SRC, 2),
+	"NXM_OF_UDP_DST":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_UDP_DST, 2),
+	"NXM_OF_ICMP_TYPE": newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ICMP_TYPE, 1),
+	"NXM_OF_ICMP_CODE": newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ICMP_CODE, 1),
+	"NXM_OF_ARP_OP":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ARP_OP, 2),
+	"NXM_OF_ARP_SPA":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ARP_SPA, 4),
+	"NXM_OF_ARP_TPA":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ARP_TPA, 4),
+
+	"NXM_NX_REG0":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG0, 4),
+	"NXM_NX_REG1":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG1, 4),
+	"NXM_NX_REG2":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG2, 4),
+	"NXM_NX_REG3":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG3, 4),
+	"NXM_NX_REG4":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG4, 4),
+	"NXM_NX_REG5":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG5, 4),
+	"NXM_NX_REG6":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG6, 4),
+	"NXM_NX_REG7":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG7, 4),
+	"NXM_NX_REG8":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG8, 4),
+	"NXM_NX_REG9":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG9, 4),
+	"NXM_NX_REG10":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG10, 4),
+	"NXM_NX_REG11":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG11, 4),
+	"NXM_NX_REG12":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG12, 4),
+	"NXM_NX_REG13":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG13, 4),
+	"NXM_NX_REG14":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG14, 4),
+	"NXM_NX_REG15":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG15, 4),
+	"NXM_NX_TUN_ID":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_ID, 8),
+	"NXM_NX_ARP_SHA":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ARP_SHA, 6),
+	"NXM_NX_ARP_THA":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ARP_THA, 6),
+	"NXM_NX_IPV6_SRC":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IPV6_SRC, 16),
+	"NXM_NX_IPV6_DST":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IPV6_DST, 16),
+	"NXM_NX_ICMPV6_TYPE":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ICMPV6_TYPE, 1),
+	"NXM_NX_ICMPV6_CODE":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ICMPV6_CODE, 1),
+	"NXM_NX_ND_TARGET":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ND_TARGET, 16),
+	"NXM_NX_ND_SLL":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ND_SLL, 6),
+	"NXM_NX_ND_TLL":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ND_TLL, 6),
+	"NXM_NX_IP_FRAG":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IP_FRAG, 1),
+	"NXM_NX_IPV6_LABEL":    newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IPV6_LABEL, 1),
+	"NXM_NX_IP_ECN":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IP_ECN, 1),
+	"NXM_NX_IP_TTL":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IP_TTL, 1),
+	"NXM_NX_MPLS_TTL":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_MPLS_TTL, 1),
+	"NXM_NX_TUN_IPV4_SRC":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV4_SRC, 4),
+	"NXM_NX_TUN_IPV4_DST":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV4_DST, 4),
+	"NXM_NX_PKT_MARK":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_PKT_MARK, 4),
+	"NXM_NX_TCP_FLAGS":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TCP_FLAGS, 2),
+	"NXM_NX_CONJ_ID":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CONJ_ID, 4),
+	"NXM_NX_TUN_GBP_ID":    newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_GBP_ID, 2),
+	"NXM_NX_TUN_GBP_FLAGS": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_GBP_FLAGS, 1),
+	"NXM_NX_TUN_FLAGS":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_FLAGS, 2),
+	"NXM_NX_CT_STATE":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_STATE, 4),
+	"NXM_NX_CT_ZONE":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_ZONE, 2),
+	"NXM_NX_CT_MARK":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_MARK, 4),
+	"NXM_NX_CT_LABEL":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_LABEL, 16),
+	"NXM_NX_TUN_IPV6_SRC":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_SRC, 16),
+	"NXM_NX_TUN_IPV6_DST":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_DST, 16),
+	"NXM_NX_TUN_METADATA0": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA0, 128),
+	"NXM_NX_TUN_METADATA1": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA1, 128),
+	"NXM_NX_TUN_METADATA2": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA2, 128),
+	"NXM_NX_TUN_METADATA3": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA3, 128),
+	"NXM_NX_TUN_METADATA4": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA4, 128),
+	"NXM_NX_TUN_METADATA5": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA5, 128),
+	"NXM_NX_TUN_METADATA6": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA6, 128),
+	"NXM_NX_TUN_METADATA7": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA7, 128),
+
+	"OXM_OF_IN_PORT":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IN_PORT, 4),
+	"OXM_OF_IN_PHY_PORT":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IN_PHY_PORT, 4),
+	"OXM_OF_METADATA":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_METADATA, 8),
+	"OXM_OF_ETH_DST":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ETH_DST, 6),
+	"OXM_OF_ETH_SRC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ETH_SRC, 6),
+	"OXM_OF_ETH_TYPE":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ETH_TYPE, 2),
+	"OXM_OF_VLAN_VID":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_VLAN_VID, 2),
+	"OXM_OF_VLAN_PCP":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_VLAN_PCP, 1),
+	"OXM_OF_IP_DSCP":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IP_DSCP, 1),
+	"OXM_OF_IP_ECN":         newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IP_ECN, 1),
+	"OXM_OF_IP_PROTO":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IP_PROTO, 1),
+	"OXM_OF_IPV4_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV4_SRC, 4),
+	"OXM_OF_IPV4_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV4_DST, 4),
+	"OXM_OF_TCP_SRC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_TCP_SRC, 2),
+	"OXM_OF_TCP_DST":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_TCP_DST, 2),
+	"OXM_OF_UDP_SRC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_UDP_SRC, 2),
+	"OXM_OF_UDP_DST":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_UDP_DST, 2),
+	"OXM_OF_SCTP_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_SCTP_SRC, 2),
+	"OXM_OF_SCTP_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_SCTP_DST, 2),
+	"OXM_OF_ICMPV4_TYPE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV4_TYPE, 1),
+	"OXM_OF_ICMPV4_CODE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV4_CODE, 1),
+	"OXM_OF_ARP_OP":         newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_OP, 2),
+	"OXM_OF_ARP_SPA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SPA, 4),
+	"OXM_OF_ARP_TPA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_TPA, 4),
+	"OXM_OF_ARP_SHA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SHA, 6),
+	"OXM_OF_ARP_THA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_THA, 6),
+	"OXM_OF_IPV6_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_SRC, 16),
+	"OXM_OF_IPV6_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_DST, 16),
+	"OXM_OF_IPV6_FLABEL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_FLABEL, 4),
+	"OXM_OF_ICMPV6_TYPE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV6_TYPE, 1),
+	"OXM_OF_ICMPV6_CODE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV6_CODE, 1),
+	"OXM_OF_IPV6_ND_TARGET": newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_ND_TARGET, 16),
+	"OXM_OF_IPV6_ND_SLL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_ND_SLL, 6),
+	"OXM_OF_IPV6_ND_TLL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_ND_TLL, 6),
+	"OXM_OF_MPLS_LABEL":     newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_MPLS_LABEL, 4),
+	"OXM_OF_MPLS_TC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_MPLS_TC, 1),
+	"OXM_OF_MPLS_BOS":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_MPLS_BOS, 1),
+	"OXM_OF_PBB_ISID":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_PBB_ISID, 3),
+	"OXM_OF_TUNNEL_ID":      newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_TUNNEL_ID, 8),
+	"OXM_OF_IPV6_EXTHDR":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_EXTHDR, 2),
+}
+
+// oxmFieldHeaderWildMap is map to find target field header with mask using an OVS known OXM field name
+var oxmFieldHeaderWildMap map[string]*MatchField
+
+func init() {
+	oxmFieldHeaderWildMap = make(map[string]*MatchField)
+	for k, v := range oxxFieldHeaderMap {
+		field := &MatchField{
+			Class:   v.Class,
+			Field:   v.Field,
+			HasMask: true,
+			Length:  v.Length * 2,
+		}
+		oxmFieldHeaderWildMap[k] = field
+	}
+}
+
+// FindFieldHeaderByName finds OXM/NXM field by name and mask.
+func FindFieldHeaderByName(fieldName string, hasMask bool) (*MatchField, error) {
+	fieldKey := strings.ToUpper(fieldName)
+	var fieldsMap map[string]*MatchField
+	if hasMask {
+		fieldsMap = oxmFieldHeaderWildMap
+	} else {
+		fieldsMap = oxxFieldHeaderMap
+	}
+	field, found := fieldsMap[fieldKey]
+	if !found {
+		return nil, fmt.Errorf("failed to find header by name %s", fieldName)
+	}
+
+	return field, nil
+}
+
+// encodeOfsNbitsStartEnd encodes the range to a uint16 number.
+func encodeOfsNbitsStartEnd(start uint16, end uint16) uint16 {
+	return (start << 6) + (end - start)
+}
+
+// Encode the range to a uint16 number.
+// ofs is the start pos, nBits is the count of the range.
+func encodeOfsNbits(ofs uint16, nBits uint16) uint16 {
+	return ofs<<6 | (nBits - 1)
+}
+
+func decodeOfs(ofsNbits uint16) uint16 {
+	return ofsNbits >> 6
+}
+
+func decodeNbits(ofsNbits uint16) uint16 {
+	return (ofsNbits & 0x3f) + 1
+}
+
+// NewNXRange creates a NXRange using start and end number.
+func NewNXRange(start int, end int) *NXRange {
+	return &NXRange{start: start, end: end}
+}
+
+// NewNXRangeByOfsNBits creates a NXRange using offshift and bit count.
+func NewNXRangeByOfsNBits(ofs int, nBits int) *NXRange {
+	return &NXRange{start: ofs, end: ofs + nBits - 1}
+}
+
+// ToUint32Mask generates a uint32 number mask from NXRange.
+func (n *NXRange) ToUint32Mask() uint32 {
+	start := n.start
+	maxLength := 32
+	var end int
+	if n.end != 0 {
+		end = n.end
+	} else {
+		end = maxLength
+	}
+	mask1 := ^uint32(0)
+	mask1 = mask1 >> uint32(maxLength-(end-n.start+1))
+	mask1 = mask1 << uint32(start)
+	return mask1
+}
+
+// ToOfsBits encodes the NXRange to a uint16 number to identify offshift and bits count.
+func (n *NXRange) ToOfsBits() uint16 {
+	return encodeOfsNbitsStartEnd(uint16(n.start), uint16(n.end))
+}
+
+// GetOfs returns the offshift number from NXRange.
+func (n *NXRange) GetOfs() uint16 {
+	return uint16(n.start)
+}
+
+// GetNbits returns the bits count from NXRange.
+func (n *NXRange) GetNbits() uint16 {
+	return uint16(n.end - n.start + 1)
+}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/nxext_test.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/nxext_test.go
@@ -1,0 +1,422 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestNXActionResubmit(t *testing.T) {
+	tableID := uint8(10)
+	portID := uint16(10)
+
+	action1 := NewNXActionResubmit(portID)
+	data1, err := action1.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to invoke NXAST_RESUBMIT.MarshalBinary: %v", err)
+	}
+	testAction1 := new(NXActionResubmitTable)
+	testAction1.UnmarshalBinary(data1)
+	if testAction1.InPort != portID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT.UnmarshalBinary, expect: %x, actual: %x", portID, testAction1.InPort)
+	}
+
+	action2 := NewNXActionResubmitTableAction(portID, tableID)
+	if action2.Length != 16 {
+		t.Errorf("Failed to create action2 NXAST_RESUBMIT_TABLE")
+	}
+	data2, err := action2.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction2 := newNXActionResubmitTable()
+	testAction2.UnmarshalBinary(data2)
+	if testAction2.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction2.TableID)
+	}
+	if testAction2.InPort != portID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", portID, testAction2.InPort)
+	}
+
+	action3 := NewNXActionResubmitTableAction(OFPP_IN_PORT, tableID)
+	if action3.Length != 16 {
+		t.Errorf("Failed to create action2 NXAST_RESUBMIT_TABLE")
+	}
+	data3, err := action3.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction3 := newNXActionResubmitTable()
+	testAction3.UnmarshalBinary(data3)
+	if testAction3.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction3.TableID)
+	}
+	if testAction3.InPort != OFPP_IN_PORT {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", portID, testAction3.InPort)
+	}
+
+	action4 := NewNXActionResubmitTableCT(portID, tableID)
+	data4, err := action4.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction4 := newNXActionResubmitTableCT()
+	testAction4.UnmarshalBinary(data4)
+	if !testAction4.IsCT() {
+		t.Error("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary")
+	}
+	if testAction4.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE_CT.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction4.TableID)
+	}
+	if testAction4.InPort != portID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE_CT.UnmarshalBinary, expect: %x, actual: %x", portID, testAction4.InPort)
+	}
+
+	action5 := NewNXActionResubmitTableCTNoInPort(tableID)
+	data5, err := action5.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction5 := newNXActionResubmitTableCT()
+	if !testAction5.IsCT() {
+		t.Error("Failed to invoke NXAST_CT_RESUBMIT.MarshalBinary")
+	}
+	testAction5.UnmarshalBinary(data5)
+	if testAction5.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_CT_RESUBMIT.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction5.TableID)
+	}
+	if testAction5.InPort != OFPP_IN_PORT {
+		t.Errorf("Failed to invoke NXAST_CT_RESUBMIT.UnmarshalBinary, expect: %x, actual: %x", portID, testAction5.InPort)
+	}
+}
+
+func TestNOfs(t *testing.T) {
+	var start, ofs, end, nBits uint16
+	start = uint16(16)
+	ofs = uint16(16)
+	nBits = uint16(16)
+	end = uint16(31)
+
+	encodeStartEnd := encodeOfsNbitsStartEnd(start, end)
+	encodeOfsNbits := encodeOfsNbits(ofs, nBits)
+	decodeOfs := decodeOfs(encodeOfsNbits)
+	deCodeNbits := decodeNbits(encodeOfsNbits)
+
+	if encodeStartEnd != encodeOfsNbits {
+		t.Errorf("Failed to encode from start to end, expect: %d, actual: %d", encodeOfsNbits, encodeStartEnd)
+	}
+	if ofs != decodeOfs {
+		t.Errorf("Failed to decode ofs, expect: %d, actual: %d", ofs, decodeOfs)
+	}
+	if nBits != deCodeNbits {
+		t.Errorf("Failed to decode nBits, expect: %d, actual: %d", nBits, deCodeNbits)
+	}
+}
+
+func TestUint32Message(t *testing.T) {
+	tgtData := uint32(0xff00ff00)
+	msg := newUint32Message(tgtData)
+	if msg.Len() != 4 {
+		t.Errorf("Failed to generate Uint32Message")
+	}
+	testData, err := msg.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.MarshalBinary, %v", err)
+	}
+	var testMsg = new(Uint32Message)
+	err = testMsg.UnmarshalBinary(testData)
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.UnmarshalBinary, %v", err)
+	}
+	if testMsg.data != tgtData {
+		t.Errorf("Failed to retrieve uint32 from Uint32Message, tgt: %d, actual: %d", tgtData, testMsg.data)
+	}
+}
+
+func TestUint16Message(t *testing.T) {
+	tgtData := uint16(0xfe10)
+	msg := newUint16Message(tgtData)
+	if msg.Len() != 2 {
+		t.Errorf("Failed to generate Uint32Message")
+	}
+	testData, err := msg.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.MarshalBinary, %v", err)
+	}
+	var testMsg = new(Uint16Message)
+	err = testMsg.UnmarshalBinary(testData)
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.UnmarshalBinary, %v", err)
+	}
+	if testMsg.data != tgtData {
+		t.Errorf("Failed to retrieve uint32 from Uint32Message, tgt: %d, actual: %d", tgtData, testMsg.data)
+	}
+}
+
+func TestNewUintXMask(t *testing.T) {
+	tgtData32 := uint32(0xff)
+	rng1 := &NXRange{start: 0, end: 7}
+	testMsg := &Uint32Message{data: rng1.ToUint32Mask()}
+	if testMsg.data != tgtData32 {
+		t.Errorf("Failed to invoke newUint32Mask, expected: %02x, actual: %02x", tgtData32, testMsg.data)
+	}
+}
+
+func TestNXMFieldHeader(t *testing.T) {
+	for k := range oxxFieldHeaderMap {
+		field1, err := FindFieldHeaderByName(k, false)
+		if err != nil {
+			t.Errorf("Test failed: %v", err)
+		}
+		testMatchFieldHeaderMarshalUnMarshal(field1, t)
+		field2, _ := FindFieldHeaderByName(k, true)
+		testMatchFieldHeaderMarshalUnMarshal(field2, t)
+	}
+}
+
+func TestCTLabel(t *testing.T) {
+	var label = [16]byte{}
+	testData, err := hex.DecodeString(fmt.Sprintf("%d", 0x12345678))
+	copy(label[:], testData)
+	field := newCTLabel(label)
+	data, err := field.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to MarshalBinary CTLabel: %v", err)
+	}
+	field2 := new(CTLabel)
+	err = field2.UnmarshalBinary(data)
+	if err != nil {
+		t.Errorf("Failed to UnmarshalBinary message: %v", err)
+	}
+	if field2.data != label {
+		t.Errorf("Unmarshalled CTLabel is incorrect, expect: %d, actual: %d", label, field2.data)
+	}
+
+	var mask = [16]byte{}
+	binary.BigEndian.PutUint32(mask[:], 0xffffffff)
+}
+
+func TestNXActionCTNAT(t *testing.T) {
+	act := NewNXActionCTNAT()
+	if err := act.SetSNAT(); err != nil {
+		t.Errorf("Failed to set SNAT action: %v", err)
+	}
+	if err := act.SetRandom(); err != nil {
+		t.Errorf("Failed to set random action: %v", err)
+	}
+	ipMin := net.ParseIP("10.0.0.200")
+	ipMax := net.ParseIP("10.0.0.240")
+	act.SetRangeIPv4Min(ipMin)
+	act.SetRangeIPv4Max(ipMax)
+	minPort := uint16(2048)
+	maxPort := uint16(10240)
+	act.SetRangeProtoMin(&minPort)
+	act.SetRangeProtoMax(&maxPort)
+	data, err := act.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to Marshal NXActionCTNAT: %v", err)
+	}
+	act2 := new(NXActionCTNAT)
+	err = act2.UnmarshalBinary(data)
+	if err != nil {
+		t.Errorf("Failed to Unmarshal NXActionCTNAT: %v", err)
+	}
+	if act2.rangeIPv4Min.String() != ipMin.String() {
+		t.Errorf("Failed to set RangeIPv4Min, expect: %s, actual: %s", ipMin.String(), act2.rangeIPv4Min.String())
+	}
+	if act2.rangeIPv4Max.String() != ipMax.String() {
+		t.Errorf("Failed to set rangeIPv4Max, expect: %s, actual: %s", ipMax.String(), act2.rangeIPv4Max.String())
+	}
+	if *act2.rangeProtoMin != minPort {
+		t.Errorf("Failed to set SetRangeProtoMin, expect: %d, actual: %d", minPort, *act2.rangeProtoMin)
+	}
+	if *act2.rangeProtoMax != maxPort {
+		t.Errorf("Failed to set SetRangeProtoMax, expect: %d, actual: %d", maxPort, *act2.rangeProtoMax)
+	}
+}
+
+func TestNXActions(t *testing.T) {
+	translateMessages(t, NewNXActionConjunction(uint8(1), uint8(3), uint32(0xffee)), new(NXActionConjunction), nxConjunctionEquals)
+
+	dstField, _ := FindFieldHeaderByName("NXM_NX_REG0", false)
+	loadData := uint64(0xf009)
+	translateMessages(t, NewNXActionRegLoad(NewNXRange(0, 31).ToOfsBits(), dstField, loadData), new(NXActionRegLoad), nxRegLoadEquals)
+
+	moveSrc, _ := FindFieldHeaderByName("NXM_OF_ETH_SRC", false)
+	moveDst, _ := FindFieldHeaderByName("NXM_OF_ETH_DST", false)
+	translateMessages(t, NewNXActionRegMove(48, 0, 0, moveSrc, moveDst), new(NXActionRegMove), nxRegMoveEquals)
+
+	outputFiled, _ := FindFieldHeaderByName("NXM_NX_REG1", false)
+	translateMessages(t, NewOutputFromField(outputFiled, NewNXRange(0, 31).ToOfsBits()), new(NXActionOutputReg), nxOutputRegEquals)
+	translateMessages(t, NewOutputFromFieldWithMaxLen(outputFiled, NewNXRange(0, 31).ToOfsBits(), uint16(0xfffe)), new(NXActionOutputReg), nxOutputRegEquals)
+
+	translateMessages(t, NewNXActionDecTTL(), new(NXActionDecTTL), nxDecTTLEquals)
+	translateMessages(t, NewNXActionDecTTLCntIDs(2, uint16(1), uint16(2)), new(NXActionDecTTLCntIDs), nxDecTTLCntIDsEquals)
+
+}
+
+func translateMessages(t *testing.T, act1, act2 Action, compare func(act1, act2 Action, stype uint16) bool) {
+	data, err := act1.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to Marshal message: %v", err)
+	}
+	err = act2.UnmarshalBinary(data)
+	if err != nil {
+		t.Fatalf("Failed to Unmarshal NXActionCTNAT: %v", err)
+	}
+	if act1.Header().Type != act1.Header().Type || act1.Header().Type != ActionType_Experimenter {
+		t.Errorf("Action type is not equal")
+	}
+	nxHeader1 := new(NXActionHeader)
+	if err = nxHeader1.UnmarshalBinary(data); err != nil {
+		t.Fatalf("Failed to unMarshal NXHeader")
+	}
+	result := compare(act1, act2, nxHeader1.Subtype)
+	if !result {
+		t.Errorf("Unmarshaled object is not equals to original one")
+	}
+}
+
+func nxConjunctionEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_CONJUNCTION {
+		return false
+	}
+	obj1 := o1.(*NXActionConjunction)
+	obj2 := o2.(*NXActionConjunction)
+	if obj1.ID != obj2.ID {
+		return false
+	}
+	if obj1.NClause != obj2.NClause {
+		return false
+	}
+	if obj1.Clause != obj2.Clause {
+		return false
+	}
+	return true
+}
+
+func nxRegLoadEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_REG_LOAD {
+		return false
+	}
+	obj1 := o1.(*NXActionRegLoad)
+	obj2 := o2.(*NXActionRegLoad)
+	if obj1.OfsNbits != obj2.OfsNbits {
+		return false
+	}
+	if obj1.DstReg.Field != obj2.DstReg.Field {
+		return false
+	}
+	if obj1.Value != obj2.Value {
+		return false
+	}
+	return true
+}
+
+func nxRegMoveEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_REG_MOVE {
+		return false
+	}
+	obj1 := o1.(*NXActionRegMove)
+	obj2 := o2.(*NXActionRegMove)
+	if obj1.DstField.Field != obj2.DstField.Field {
+		return false
+	}
+	if obj1.SrcField.Field != obj2.SrcField.Field {
+		return false
+	}
+	if obj1.SrcOfs != obj2.SrcOfs {
+		return false
+	}
+	if obj1.DstOfs != obj2.DstOfs {
+		return false
+	}
+	if obj1.Nbits != obj2.Nbits {
+		return false
+	}
+	return true
+}
+
+func nxOutputRegEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_OUTPUT_REG {
+		return false
+	}
+	obj1 := o1.(*NXActionOutputReg)
+	obj2 := o2.(*NXActionOutputReg)
+	if obj1.SrcField.Field != obj2.SrcField.Field {
+		return false
+	}
+	if obj1.OfsNbits != obj2.OfsNbits {
+		return false
+	}
+	if obj1.MaxLen != obj2.MaxLen {
+		return false
+	}
+	return true
+}
+
+func nxDecTTLEquals(o1 Action, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_DEC_TTL {
+		return false
+	}
+	obj1 := o1.(*NXActionDecTTL)
+	obj2 := o2.(*NXActionDecTTL)
+	if obj1.controllers != obj2.controllers {
+		return false
+	}
+	if obj2.controllers != 0 {
+		return false
+	}
+	return true
+}
+
+func nxDecTTLCntIDsEquals(o1 Action, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_DEC_TTL_CNT_IDS {
+		return false
+	}
+	obj1 := o1.(*NXActionDecTTLCntIDs)
+	obj2 := o2.(*NXActionDecTTLCntIDs)
+	if obj1.controllers != obj2.controllers {
+		return false
+	}
+	if len(obj1.cntIDs) != len(obj2.cntIDs) {
+		return false
+	}
+	obj1CntMap := make(map[uint16]bool)
+	for _, id := range obj1.cntIDs {
+		obj1CntMap[id] = true
+	}
+
+	for _, id := range obj2.cntIDs {
+		_, exist := obj1CntMap[id]
+		if !exist {
+			return false
+		}
+	}
+	return true
+}
+
+func testMatchFieldHeaderMarshalUnMarshal(tgtField *MatchField, t *testing.T) {
+	headerInt := tgtField.MarshalHeader()
+	testMFHeader := new(MatchField)
+	var data = make([]byte, 4)
+	binary.BigEndian.PutUint32(data, headerInt)
+	err := testMFHeader.UnmarshalHeader(data)
+	if err != nil {
+		t.Errorf("Failed to UnmarshalHeader: %v", err)
+	}
+	if testMFHeader.Class != tgtField.Class {
+		t.Errorf("Unmarshalled header has incorrect 'Class' field, expect: %d, actual: %d", testMFHeader.Class, tgtField.Class)
+	}
+	if testMFHeader.Field != tgtField.Field {
+		t.Errorf("Unmarshalled header has incorrect 'Field' field, expect: %d, actual: %d", testMFHeader.Field, tgtField.Field)
+	}
+	if testMFHeader.HasMask != tgtField.HasMask {
+		t.Errorf("Unmarshalled header has incorrect 'HasMask' field, expect: %v, actual: %v", testMFHeader.HasMask, tgtField.HasMask)
+	}
+	if testMFHeader.Length != tgtField.Length {
+		t.Errorf("Unmarshalled header has incorrect 'Length' field, expect: %d, actual: %d", testMFHeader.Length, tgtField.Length)
+	}
+}

--- a/vendor/github.com/contiv/libOpenflow/openflow13/openflow13.go
+++ b/vendor/github.com/contiv/libOpenflow/openflow13/openflow13.go
@@ -261,7 +261,10 @@ func (p *PacketOut) UnmarshalBinary(data []byte) error {
 	n += 6 // for pad
 
 	for n < (n + p.ActionsLen) {
-		a := DecodeAction(data[n:])
+		a, err := DecodeAction(data[n:])
+		if err != nil {
+			return err
+		}
 		p.Actions = append(p.Actions, a)
 		n += a.Len()
 	}


### PR DESCRIPTION
1. Support NX extension of actions: resubmit, output to NX register working as FgraphElem. resubmit is also working as FlowAction, for OVS supports one flow entry has multiple resubmit actions, but Flow model in ofnet has only one nextElem.
2. Add support for NX extenstions. Extended actions include: load, move, conjunction, ct, and extended match include regX[m.n], ct_state, ct_mark, conj_id
3. Support controller to initiate connections to OFSwitch with Unix Domain Socket.
4. Enhance OFSwitch to support dump Openflow entries using MultipartRequest. This feature could help check flow realize status.